### PR TITLE
Feature save state

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>. 
 -->
 
-# P4 (Polynomial Planar Phase Portraits) version 6.0.0
+# P4 (Polynomial Planar Phase Portraits) version 7.0.0
 
 ## Description
 
 P4 is a software that is able to draw the planar phase portrait for any polynomial differential system on the Poincaré or Poincaré-Lyapunov compactified planes.
 
-Check the installation instructions for [Linux][linux_install], [Windows][windows_install] and [macOS][macOS_install], and also check out the [FAQ][faq].
+Check the installation instructions for [Linux][linux_install], [Windows][windows_install] and [macOS][macOS_install], and also check out the [FAQ][faq] or [open an issue](https://github.com/oscarsaleta/P4/issues/new "new P4 issue") if you have any problems with the software.
 
 ![Main window](help/screenshots/p4_main_window.png)|![Plot window](help/screenshots/p4_plot_poincare.png)
 :-------------------------------------------------:|:---------------------------------------------------:
@@ -213,8 +213,10 @@ Check [here][binary_tree] for instructions of how to create a correct file tree 
         * If the path is wrong: check that you defined correctly the `P4_DIR` environment variable in _.bashrc_ (or _.zhsrc_, or any other shell configuration file you use). Also, within P4, go to _About P4... > Main Settings_ and check that the _Base installation Path_ and the _Sumtable Path_ fields point correctly to your P4 installation directory.
 - I installed P4 and it executes, but when I press _Evaluate_ the output says "_Error, at offset 17729 in `/usr/local/p4/bin/p4.m`, unexpected DAG type: 0,122,(z)_" (or similar) and then does nothing.
     + This is a known bug that still has not been solved. We suspect it has to do with older Maple versions not being fully compatible with P4. P4 has been tested with Maple 17, 18 and 2015 (and recently 2017 thanks to a commited user), but older Maple versions could cause incompatibilities.
-    + Our advice is to either acquire a newer Maple version, or use an older P4 version where this
-    issue does not appear (as of now, the latest P4 version without this problem is v3.3.3).
+    + Our advice is to either acquire a newer Maple version, or use an older P4 version where this issue does not appear (as of now, the latest P4 version without this problem is v3.3.3).
+- Where are my files and images saved?
+    + It depends on the OS: for Linux and Mac, the files are stored in the current working directory of the Terminal that executed P4. For Windows, the files are all saved to _C:\Users\currentUser\Documents\P4_ or the equivalent Documents directory.
+    + The name of the files depends on the name inputted in the field _Name_ on top of the P4 application. Be careful, because if you use the same name for printing two different vector fields, the oldest will be replaced.
 
     
 ## Contributors

--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ Check [release page][latest_release] to see more detailed instructions and downl
         + Debian-based (Debian/Ubuntu/Mint): `sudo apt-get install libmpfr-dev`
         + Fedora-based (Fedora/Kokora/Arquetype): `sudo dnf install mpfr-devel`
         + Arch-based (Archlinux/Angergos): `sudo pacman -S gmp mpfr`
+    - Boost libraries (version 1.62.0 used in development, should work with older versions too):
+        + Debian-based (Debian/Ubuntu/Mint): `sudo apt-get install libboost-dev`
+        + Fedora-based (Fedora/Kokora/Arquetype): `sudo dnf install boost-devel`
+        + Arch-based (Archlinux/Angergos): `sudo pacman -S boost`
 * **Compilation from source using Qt Creator:**
     - Dependencies itemized above,
 	- Qt Creator IDE:
@@ -102,6 +106,7 @@ Check [release page][latest_release] to see more detailed instructions and downl
         + Download from [Qt website](https://www.qt.io/ "Qt official website"),
 	- C++ compiler: Microsoft Visual C++ Compiler (tested with versions 14.0 and 15.0).
         + Download from [Visual Studio Community](https://www.visualstudio.com/vs/cplusplus/#downloads "Visual Studio Community C++ download").
+    - Boost libraries: download and install from [Boost website](http://www.boost.org/ "Boost official website").
 
 
 ## macOS
@@ -139,6 +144,8 @@ Check [release page][latest_release] to see more detailed instructions and downl
         + Follow the instructions (_IMPORTANT: modify the PATH as the installer suggests so the system will be able to find the libraries_)
     - MPFR library: installed using Homebrew
         + Run in terminal `brew install mpfr`
+    - Boost libraries (development uses version 1.62.0):
+        + Run in terminal `brew install boost`
     - _You will need to open a new terminal if you updated the PATH for the changes to take effect_
 
 

--- a/compile_install_p4
+++ b/compile_install_p4
@@ -287,6 +287,16 @@ function error_compiler {
     fi
 }
 
+function error_boost {
+    if [[ "${platform}" == 'linux' ]]; then
+        echo "${bold}${red}[Error]${normal} Boost libraries are needed for some dynamic properties of P4 to work."
+        echo "Install them using the proper method for your distribution, e.g.:"
+        echo "    - Debian-based (Debian/Ubuntu/Mint): sudo apt-get install libboost-dev"
+        echo "    - Fedora-based (Fedora/Kokora/Arquetype): sudo dnf install boost-devel"
+        echo "    - Arch-based (Archlinux/Antergos): sudo pacman -S boost"
+    fi
+}
+
 if [[ "${platform}" == 'linux' ]]; then
     function error_qtmodules {
         echo "${bold}${red}[Error]${normal} Some Qt5 modules were not found in the system."
@@ -312,6 +322,7 @@ if [[ "${platform}" == 'linux' ]]; then
         echo "have permission to use this command."
         echo ""
     }
+
 fi
 
 
@@ -479,21 +490,38 @@ if [[ "${platform}" == 'linux' ]]; then
     # ldconfig check
     if (command -v ldconfig >/dev/null 2>&1); then
         echo "${green}[Success]${normal}"
-        echo "- Looking for compiler libraries..."
         # gcc libraries check
+        echo "- Looking for compiler libraries..."
         if (ldconfig -p | grep libstdc++ >/dev/null && ldconfig -p | grep libgcc_s >/dev/null && ldconfig -p | grep libc >/dev/null); then
             echo "${green}[Success]${normal}"
         else
             error_compiler
             exit 1
         fi
+        # boost libs check
+        echo "- Looking for Boost libraries..."
+        if (ldconfig -p | grep libboost >/dev/null); then
+            echo "${green}[Success]${normal}"
+        else
+            error_boost
+            exit 1
+        fi
     else
         echo "[Warning] ldconfig could not be executed, trying as super user..."
         # gcc libraries check
+        echo "- Looking for compiler libraries..."
         if (sudo ldconfig -p | grep libstdc++ >/dev/null && sudo ldconfig -p | grep libgcc_s >/dev/null && sudo ldconfig -p | grep libc >/dev/null); then
             echo "${green}[Success]${normal}"
         else
             error_ldconfig
+            exit 1
+        fi
+        echo "- Looking for Boost libraries..."
+        # boost libs check
+        if (sudo ldconfig -p | grep libboost >/dev/null); then
+            echo "${green}[Success]${normal}"
+        else
+            error_boost
             exit 1
         fi
     fi

--- a/compile_install_p4
+++ b/compile_install_p4
@@ -288,13 +288,16 @@ function error_compiler {
 }
 
 function error_boost {
+    echo "${bold}${red}[Error]${normal} Boost libraries are needed for some dynamic properties of P4 to work."
     if [[ "${platform}" == 'linux' ]]; then
-        echo "${bold}${red}[Error]${normal} Boost libraries are needed for some dynamic properties of P4 to work."
         echo "Install them using the proper method for your distribution, e.g.:"
         echo "    - Debian-based (Debian/Ubuntu/Mint): sudo apt-get install libboost-dev"
         echo "    - Fedora-based (Fedora/Kokora/Arquetype): sudo dnf install boost-devel"
         echo "    - Arch-based (Archlinux/Antergos): sudo pacman -S boost"
+    elif [[ "{platform}" == 'darwin' ]]; then
+        echo "You can install it using this command in a terminal: brew install boost"
     fi
+    echo ""
 }
 
 if [[ "${platform}" == 'linux' ]]; then
@@ -524,6 +527,13 @@ if [[ "${platform}" == 'linux' ]]; then
             error_boost
             exit 1
         fi
+    fi
+elif [[ ${platform} == 'darwin' ]]; then
+    echo "- Looking for Boost libraries..."
+    if (ls /usr/local/include | grep libboost >/dev/null); then
+        echo "${green}[Success]${normal}"
+    else
+        error_boost
     fi
 fi
 

--- a/src-gui/p4/custom.h
+++ b/src-gui/p4/custom.h
@@ -197,6 +197,11 @@ namespace bgColours
 extern int CFOREGROUND; // foreground color
 extern int CBACKGROUND; // background color
 extern int CORBIT;      // orbits (use GREEN1 when background is white)
+// IN PRINT_BITMAP.CPP: PrintColorTable shows how these colors are treated when
+// printing.
+// For example, when printing, BLACK can be reversed with WHITE, so that the
+// BLACK background on screen is not printed black.
+extern bool PRINT_REVERSE_BLACK_AND_WHITE; 
 }
 
 #define CSADDLE_NODE MAGENTA                   // saddle-node
@@ -223,16 +228,6 @@ extern int CORBIT;      // orbits (use GREEN1 when background is white)
 #define CCURV CYAN
 #define CISOC PINK1
 
-// IN PRINT_BITMAP.CPP: PrintColorTable shows how these colors are treated when
-// printing.
-// For example, when printing, BLACK can be reversed with WHITE, so that the
-// BLACK
-// background on screen is not printed black.
-
-// comment following line if you want an EXACT screen copy (with black
-// background)
-
-#define PRINT_REVERSE_BLACK_AND_WHITE
 
 //#define   USE_SYSTEM_PRINTER          // comment when system printer fails
 

--- a/src-gui/p4/custom.h
+++ b/src-gui/p4/custom.h
@@ -201,7 +201,7 @@ extern int CORBIT;      // orbits (use GREEN1 when background is white)
 // printing.
 // For example, when printing, BLACK can be reversed with WHITE, so that the
 // BLACK background on screen is not printed black.
-extern bool PRINT_REVERSE_BLACK_AND_WHITE; 
+extern bool PRINT_WHITE_BG; 
 }
 
 #define CSADDLE_NODE MAGENTA                   // saddle-node

--- a/src-gui/p4/custom.h
+++ b/src-gui/p4/custom.h
@@ -192,22 +192,25 @@
 // Choose one of the constants defined in COLOR.H
 
 // Color of singular points:
+namespace bgColours
+{
+extern int CFOREGROUND; // foreground color
+extern int CBACKGROUND; // background color
+extern int CORBIT;      // orbits (use GREEN1 when background is white)
+}
 
-#define CFOREGROUND WHITE
-#define CBACKGROUND BLACK
-
-#define CSADDLE_NODE MAGENTA        // saddle-node
-#define CSADDLE GREEN2              // saddle
-#define CNODE_S BLUE                // stable node
-#define CNODE_U RED                 // unstable node
-#define CWEAK_FOCUS CFOREGROUND     // weak focus
-#define CWEAK_FOCUS_S BLUE2         // stable weak focus
-#define CWEAK_FOCUS_U RED2          // unstable weak focus
-#define CSTRONG_FOCUS_S BLUE        // stable strong focus
-#define CSTRONG_FOCUS_U RED         // unstable strong focus
-#define CCENTER GREEN2              // center
-#define CDEGEN CFOREGROUND          // degenerated
-#define CLINEATINFINITY CFOREGROUND // color of poincare sphere
+#define CSADDLE_NODE MAGENTA                   // saddle-node
+#define CSADDLE GREEN2                         // saddle
+#define CNODE_S BLUE                           // stable node
+#define CNODE_U RED                            // unstable node
+#define CWEAK_FOCUS bgColours::CFOREGROUND     // weak focus
+#define CWEAK_FOCUS_S BLUE2                    // stable weak focus
+#define CWEAK_FOCUS_U RED2                     // unstable weak focus
+#define CSTRONG_FOCUS_S BLUE                   // stable strong focus
+#define CSTRONG_FOCUS_U RED                    // unstable strong focus
+#define CCENTER GREEN2                         // center
+#define CDEGEN bgColours::CFOREGROUND          // degenerated
+#define CLINEATINFINITY bgColours::CFOREGROUND // color of poincare sphere
 
 #define CSTABLE BLUE        // stable separatrice
 #define CUNSTABLE RED       // unstable separatrice
@@ -215,7 +218,6 @@
 #define CCENT_UNSTABLE RED1 // center-unstable separatrice
 
 #define CW_SEP GOLD     // selected separatrice
-#define CORBIT YELLOW   // orbits (use GREEN1 when background is white)
 #define CLIMIT MAGENTA2 // limit cycles
 #define CSING GREEN     // curve of singularities
 #define CCURV CYAN

--- a/src-gui/p4/file_vf.cpp
+++ b/src-gui/p4/file_vf.cpp
@@ -453,6 +453,8 @@ bool QInputVF::save(void)
     fclose(fp);
     changed_ = false;
     return true;
+
+    emit saveSignal();
 }
 
 QString QInputVF::getbarefilename(void) const

--- a/src-gui/p4/file_vf.cpp
+++ b/src-gui/p4/file_vf.cpp
@@ -30,8 +30,6 @@
 #include <QDir>
 #include <QFileInfo>
 
-#include <iostream>
-
 #ifdef Q_OS_WIN
 #include <windows.h>
 #endif
@@ -167,7 +165,6 @@ void QInputVF::reset(void)
 bool QInputVF::load(void)
 {
     emit loadSignal();
-    std::cerr << "Emited load signal" << std::endl;
 
     FILE *fp;
     QString fname;
@@ -373,7 +370,6 @@ bool QInputVF::checkevaluated(void)
 bool QInputVF::save(void)
 {
     emit saveSignal();
-    std::cerr << "Sent save signal" << std::endl;
 
     FILE *fp;
     int i;

--- a/src-gui/p4/file_vf.cpp
+++ b/src-gui/p4/file_vf.cpp
@@ -29,6 +29,7 @@
 #include <QDateTime>
 #include <QDir>
 #include <QFileInfo>
+#include <QSettings>
 
 #ifdef Q_OS_WIN
 #include <windows.h>
@@ -369,6 +370,9 @@ bool QInputVF::checkevaluated(void)
 // -----------------------------------------------------------------------
 bool QInputVF::save(void)
 {
+    QSettings settings(getbarefilename().append(".conf"),
+                       QSettings::NativeFormat);
+    settings.clear();
     emit saveSignal();
 
     FILE *fp;

--- a/src-gui/p4/file_vf.cpp
+++ b/src-gui/p4/file_vf.cpp
@@ -30,6 +30,8 @@
 #include <QDir>
 #include <QFileInfo>
 
+#include <iostream>
+
 #ifdef Q_OS_WIN
 #include <windows.h>
 #endif
@@ -164,6 +166,9 @@ void QInputVF::reset(void)
 // -----------------------------------------------------------------------
 bool QInputVF::load(void)
 {
+    emit loadSignal();
+    std::cerr << "Emited load signal" << std::endl;
+
     FILE *fp;
     QString fname;
     char scanbuf[2560];
@@ -367,6 +372,9 @@ bool QInputVF::checkevaluated(void)
 // -----------------------------------------------------------------------
 bool QInputVF::save(void)
 {
+    emit saveSignal();
+    std::cerr << "Sent save signal" << std::endl;
+
     FILE *fp;
     int i;
     QString fname;
@@ -453,8 +461,6 @@ bool QInputVF::save(void)
     fclose(fp);
     changed_ = false;
     return true;
-
-    emit saveSignal();
 }
 
 QString QInputVF::getbarefilename(void) const

--- a/src-gui/p4/file_vf.h
+++ b/src-gui/p4/file_vf.h
@@ -190,6 +190,9 @@ class QInputVF : public QObject
 
     void createProcessWindow();
 
+  signals:
+    void saveSignal();
+
   public slots:
     void finishEvaluation(int);
     void catchProcessError(QProcess::ProcessError);

--- a/src-gui/p4/file_vf.h
+++ b/src-gui/p4/file_vf.h
@@ -192,6 +192,7 @@ class QInputVF : public QObject
 
   signals:
     void saveSignal();
+    void loadSignal();
 
   public slots:
     void finishEvaluation(int);

--- a/src-gui/p4/math_gcf.cpp
+++ b/src-gui/p4/math_gcf.cpp
@@ -46,7 +46,7 @@ bool evalGcfStart(QWinSphere *sp, int dashes, int points, int precis)
 {
     if (g_VFResults.gcf_points_ != nullptr) {
         sp->prepareDrawing();
-        draw_gcf(sp, g_VFResults.gcf_points_, CBACKGROUND, s_GcfDashes);
+        draw_gcf(sp, g_VFResults.gcf_points_, bgColours::CBACKGROUND, s_GcfDashes);
         sp->finishDrawing();
         g_VFResults.deleteOrbitPoint(g_VFResults.gcf_points_);
         g_VFResults.gcf_points_ = nullptr;

--- a/src-gui/p4/math_orbits.cpp
+++ b/src-gui/p4/math_orbits.cpp
@@ -47,7 +47,8 @@ void integrateOrbit(QWinSphere *sphere, int dir)
                       pcoord);
         g_VFResults.current_orbit_->current_f_orbits->next_point =
             integrate_orbit(sphere, pcoord, g_VFResults.config_currentstep_,
-                            dir, CORBIT, g_VFResults.config_intpoints_, &sep);
+                            dir, bgColours::CORBIT,
+                            g_VFResults.config_intpoints_, &sep);
 
         g_VFResults.current_orbit_->current_f_orbits = sep;
         return;
@@ -60,9 +61,9 @@ void integrateOrbit(QWinSphere *sphere, int dir)
             dir = -dir;
 
     if (g_VFResults.current_orbit_->f_orbits == nullptr) {
-        g_VFResults.current_orbit_->f_orbits =
-            integrate_orbit(sphere, pcoord, g_VFResults.config_step_, dir,
-                            CORBIT, g_VFResults.config_intpoints_, &sep);
+        g_VFResults.current_orbit_->f_orbits = integrate_orbit(
+            sphere, pcoord, g_VFResults.config_step_, dir, bgColours::CORBIT,
+            g_VFResults.config_intpoints_, &sep);
     } else {
         g_VFResults.current_orbit_->current_f_orbits->next_point =
             new orbits_points;
@@ -71,11 +72,12 @@ void integrateOrbit(QWinSphere *sphere, int dir)
         copy_x_into_y(pcoord,
                       g_VFResults.current_orbit_->current_f_orbits->pcoord);
         g_VFResults.current_orbit_->current_f_orbits->dashes = 0;
-        g_VFResults.current_orbit_->current_f_orbits->color = CORBIT;
+        g_VFResults.current_orbit_->current_f_orbits->color = bgColours::CORBIT;
         g_VFResults.current_orbit_->current_f_orbits->dir = dir;
         g_VFResults.current_orbit_->current_f_orbits->next_point =
             integrate_orbit(sphere, pcoord, g_VFResults.config_step_, dir,
-                            CORBIT, g_VFResults.config_intpoints_, &sep);
+                            bgColours::CORBIT, g_VFResults.config_intpoints_,
+                            &sep);
     }
     g_VFResults.current_orbit_->current_f_orbits = sep;
 }
@@ -103,12 +105,12 @@ bool startOrbit(QWinSphere *sphere, double x, double y, bool R)
         MATHFUNC(viewcoord_to_sphere)(x, y, pcoord);
 
     copy_x_into_y(pcoord, g_VFResults.current_orbit_->pcoord);
-    g_VFResults.current_orbit_->color = CORBIT;
+    g_VFResults.current_orbit_->color = bgColours::CORBIT;
     g_VFResults.current_orbit_->f_orbits = nullptr;
     g_VFResults.current_orbit_->next_orbit = nullptr;
 
     MATHFUNC(sphere_to_viewcoord)(pcoord[0], pcoord[1], pcoord[2], ucoord);
-    sphere->drawPoint(ucoord[0], ucoord[1], CORBIT);
+    sphere->drawPoint(ucoord[0], ucoord[1], bgColours::CORBIT);
 
     return true;
 }

--- a/src-gui/p4/math_separatrice.cpp
+++ b/src-gui/p4/math_separatrice.cpp
@@ -1137,7 +1137,7 @@ void change_epsilon_saddle(QWinSphere *spherewnd, double epsilon)
     g_VFResults.selected_saddle_point_->epsilon = epsilon;
     separatrice = g_VFResults.selected_saddle_point_->separatrices;
     while (separatrice != nullptr) {
-        draw_selected_sep(spherewnd, separatrice->first_sep_point, CBACKGROUND);
+        draw_selected_sep(spherewnd, separatrice->first_sep_point, bgColours::CBACKGROUND);
         g_VFResults.deleteOrbitPoint(separatrice->first_sep_point);
         separatrice->last_sep_point = nullptr;
         separatrice->first_sep_point = nullptr;
@@ -1152,7 +1152,7 @@ void change_epsilon_se(QWinSphere *spherewnd, double epsilon)
     g_VFResults.selected_se_point_->epsilon = epsilon;
     separatrice = g_VFResults.selected_se_point_->separatrices;
     while (separatrice != nullptr) {
-        draw_selected_sep(spherewnd, separatrice->first_sep_point, CBACKGROUND);
+        draw_selected_sep(spherewnd, separatrice->first_sep_point, bgColours::CBACKGROUND);
         g_VFResults.deleteOrbitPoint(separatrice->first_sep_point);
         separatrice->last_sep_point = nullptr;
         separatrice->first_sep_point = nullptr;
@@ -1167,7 +1167,7 @@ void change_epsilon_de(QWinSphere *spherewnd, double epsilon)
     g_VFResults.selected_de_point_->epsilon = epsilon;
     separatrice = g_VFResults.selected_de_point_->blow_up;
     while (separatrice != nullptr) {
-        draw_selected_sep(spherewnd, separatrice->first_sep_point, CBACKGROUND);
+        draw_selected_sep(spherewnd, separatrice->first_sep_point, bgColours::CBACKGROUND);
         g_VFResults.deleteOrbitPoint(separatrice->first_sep_point);
         separatrice->last_sep_point = nullptr;
         separatrice->first_sep_point = nullptr;

--- a/src-gui/p4/p4.pro
+++ b/src-gui/p4/p4.pro
@@ -32,7 +32,7 @@ CONFIG -= console
 macx {
     CONFIG -= app_bundle
     QMAKE_LFLAGS += -L/usr/local/opt/qt/lib
-    QMAKE_CXXFLAGS += -I/usr/local/opt/qt/include
+    QMAKE_CXXFLAGS += -I/usr/local/opt/qt/include -I/usr/local/include
 }
 
 DESTDIR = $$BUILD_DIR/p4/

--- a/src-gui/p4/print_bitmap.cpp
+++ b/src-gui/p4/print_bitmap.cpp
@@ -24,23 +24,6 @@
 #include "plot_tools.h"
 #include "print_points.h"
 
-int g_printColorTable[NUMXFIGCOLORS] =
-
-#ifdef PRINT_REVERSE_BLACK_AND_WHITE
-    {WHITE, // black --> white when printing
-     BLUE,   GREEN,  CYAN,   RED,   MAGENTA,
-     BLACK, // yellow --> black when printing
-     BLACK, // white --> black when printing
-     BLUE1,  BLUE2,  BLUE3,  BLUE4, GREEN1,  GREEN2,   GREEN3,   CYAN1,
-     CYAN2,  CYAN3,  RED1,   RED2,  RED3,    MAGENTA1, MAGENTA2, MAGENTA3,
-     BROWN1, BROWN2, BROWN3, PINK1, PINK2,   PINK3,    PINK4,    GOLD};
-#else
-    {BLACK,  BLUE,   GREEN,  CYAN,  RED,    MAGENTA,  YELLOW,   WHITE,
-     BLUE1,  BLUE2,  BLUE3,  BLUE4, GREEN1, GREEN2,   GREEN3,   CYAN1,
-     CYAN2,  CYAN3,  RED1,   RED2,  RED3,   MAGENTA1, MAGENTA2, MAGENTA3,
-     BROWN1, BROWN2, BROWN3, PINK1, PINK2,  PINK3,    PINK4,    GOLD};
-#endif
-
 static bool s_P4PrintBlackWhite = true;
 
 static QPainter *s_P4PrintPainter = nullptr;
@@ -52,6 +35,25 @@ static int s_LastP4PrintY0 = 0;
 static int s_LastP4Printcolor = 0;
 
 // ---------------------------------------------------------------------------------------
+int printColorTable(int color) {
+    int colorTable[NUMXFIGCOLORS] = {WHITE, // black --> white when printing
+            BLUE,   GREEN,  CYAN,   RED,   MAGENTA,
+            BLACK, // yellow --> black when printing
+            BLACK, // white --> black when printing
+            BLUE1,  BLUE2,  BLUE3,  BLUE4, GREEN1,  GREEN2,   GREEN3,   CYAN1,
+            CYAN2,  CYAN3,  RED1,   RED2,  RED3,    MAGENTA1, MAGENTA2, MAGENTA3,
+            BROWN1, BROWN2, BROWN3, PINK1, PINK2,   PINK3,    PINK4,    GOLD};
+    int colorTableReverse[NUMXFIGCOLORS] = {BLACK,  BLUE,   GREEN,  CYAN,  RED,    MAGENTA,  YELLOW,   WHITE,
+            BLUE1,  BLUE2,  BLUE3,  BLUE4, GREEN1, GREEN2,   GREEN3,   CYAN1,
+            CYAN2,  CYAN3,  RED1,   RED2,  RED3,   MAGENTA1, MAGENTA2, MAGENTA3,
+            BROWN1, BROWN2, BROWN3, PINK1, PINK2,  PINK3,    PINK4,    GOLD};
+
+    if (bgColours::PRINT_WHITE_BG)
+        return colorTable[color];
+    else
+        return colorTableReverse[color];
+}
+
 
 static void P4Print_comment(QString s)
 {
@@ -68,9 +70,9 @@ static void P4Print_print_saddle(double _x, double _y)
     y = (int)_y;
 
     if (s_P4PrintBlackWhite)
-        color = g_printColorTable[bgColours::CFOREGROUND];
+        color = printColorTable(bgColours::CFOREGROUND);
     else
-        color = g_printColorTable[CSADDLE];
+        color = printColorTable(CSADDLE);
 
     s_P4PrintPainter->setPen(QXFIGCOLOR(color));
     s_P4PrintPainter->setBrush(QXFIGCOLOR(color));
@@ -91,9 +93,9 @@ static void P4Print_print_stablenode(double _x, double _y)
     y = (int)_y;
 
     if (s_P4PrintBlackWhite)
-        color = g_printColorTable[bgColours::CFOREGROUND];
+        color = printColorTable(bgColours::CFOREGROUND);
     else
-        color = g_printColorTable[CNODE_S];
+        color = printColorTable(CNODE_S);
 
     s_P4PrintPainter->setPen(QXFIGCOLOR(color));
     s_P4PrintPainter->setBrush(QXFIGCOLOR(color));
@@ -113,9 +115,9 @@ static void P4Print_print_unstablenode(double _x, double _y)
     y = (int)_y;
 
     if (s_P4PrintBlackWhite)
-        color = g_printColorTable[bgColours::CFOREGROUND];
+        color = printColorTable(bgColours::CFOREGROUND);
     else
-        color = g_printColorTable[CNODE_U];
+        color = printColorTable(CNODE_U);
 
     s_P4PrintPainter->setPen(QXFIGCOLOR(color));
     s_P4PrintPainter->setBrush(QXFIGCOLOR(color));
@@ -135,9 +137,9 @@ static void P4Print_print_stableweakfocus(double _x, double _y)
     x = (int)_x;
     y = (int)_y;
     if (s_P4PrintBlackWhite)
-        color = g_printColorTable[bgColours::CFOREGROUND];
+        color = printColorTable(bgColours::CFOREGROUND);
     else
-        color = g_printColorTable[CWEAK_FOCUS_S];
+        color = printColorTable(CWEAK_FOCUS_S);
 
     s_P4PrintPainter->setPen(QXFIGCOLOR(color));
     s_P4PrintPainter->setBrush(QXFIGCOLOR(color));
@@ -162,9 +164,9 @@ static void P4Print_print_unstableweakfocus(double _x, double _y)
     x = (int)_x;
     y = (int)_y;
     if (s_P4PrintBlackWhite)
-        color = g_printColorTable[bgColours::CFOREGROUND];
+        color = printColorTable(bgColours::CFOREGROUND);
     else
-        color = g_printColorTable[CWEAK_FOCUS_U];
+        color = printColorTable(CWEAK_FOCUS_U);
 
     s_P4PrintPainter->setPen(QXFIGCOLOR(color));
     s_P4PrintPainter->setBrush(QXFIGCOLOR(color));
@@ -190,9 +192,9 @@ static void P4Print_print_weakfocus(double _x, double _y)
     y = (int)_y;
 
     if (s_P4PrintBlackWhite)
-        color = g_printColorTable[bgColours::CFOREGROUND];
+        color = printColorTable(bgColours::CFOREGROUND);
     else
-        color = g_printColorTable[CWEAK_FOCUS];
+        color = printColorTable(CWEAK_FOCUS);
 
     s_P4PrintPainter->setPen(QXFIGCOLOR(color));
     s_P4PrintPainter->setBrush(QXFIGCOLOR(color));
@@ -218,9 +220,9 @@ static void P4Print_print_center(double _x, double _y)
     y = (int)_y;
 
     if (s_P4PrintBlackWhite)
-        color = g_printColorTable[bgColours::CFOREGROUND];
+        color = printColorTable(bgColours::CFOREGROUND);
     else
-        color = g_printColorTable[CCENTER];
+        color = printColorTable(CCENTER);
 
     s_P4PrintPainter->setPen(QXFIGCOLOR(color));
     s_P4PrintPainter->setBrush(QXFIGCOLOR(color));
@@ -246,9 +248,9 @@ static void P4Print_print_stablestrongfocus(double _x, double _y)
     y = (int)_y;
 
     if (s_P4PrintBlackWhite)
-        color = g_printColorTable[bgColours::CFOREGROUND];
+        color = printColorTable(bgColours::CFOREGROUND);
     else
-        color = g_printColorTable[CSTRONG_FOCUS_S];
+        color = printColorTable(CSTRONG_FOCUS_S);
 
     s_P4PrintPainter->setPen(QXFIGCOLOR(color));
     s_P4PrintPainter->setBrush(QXFIGCOLOR(color));
@@ -273,9 +275,9 @@ static void P4Print_print_unstablestrongfocus(double _x, double _y)
     y = (int)_y;
 
     if (s_P4PrintBlackWhite)
-        color = g_printColorTable[bgColours::CFOREGROUND];
+        color = printColorTable(bgColours::CFOREGROUND);
     else
-        color = g_printColorTable[CSTRONG_FOCUS_U];
+        color = printColorTable(CSTRONG_FOCUS_U);
 
     s_P4PrintPainter->setPen(QXFIGCOLOR(color));
     s_P4PrintPainter->setBrush(QXFIGCOLOR(color));
@@ -301,9 +303,9 @@ static void P4Print_print_sesaddle(double _x, double _y)
     y = (int)_y;
 
     if (s_P4PrintBlackWhite)
-        color = g_printColorTable[bgColours::CFOREGROUND];
+        color = printColorTable(bgColours::CFOREGROUND);
     else
-        color = g_printColorTable[CSADDLE];
+        color = printColorTable(CSADDLE);
 
     s_P4PrintPainter->setPen(QXFIGCOLOR(color));
     s_P4PrintPainter->setBrush(QXFIGCOLOR(color));
@@ -328,9 +330,9 @@ static void P4Print_print_sesaddlenode(double _x, double _y)
     y = (int)_y;
 
     if (s_P4PrintBlackWhite)
-        color = g_printColorTable[bgColours::CFOREGROUND];
+        color = printColorTable(bgColours::CFOREGROUND);
     else
-        color = g_printColorTable[CSADDLE_NODE];
+        color = printColorTable(CSADDLE_NODE);
 
     s_P4PrintPainter->setPen(QXFIGCOLOR(color));
     s_P4PrintPainter->setBrush(QXFIGCOLOR(color));
@@ -354,9 +356,9 @@ static void P4Print_print_sestablenode(double _x, double _y)
     y = (int)_y;
 
     if (s_P4PrintBlackWhite)
-        color = g_printColorTable[bgColours::CFOREGROUND];
+        color = printColorTable(bgColours::CFOREGROUND);
     else
-        color = g_printColorTable[CNODE_S];
+        color = printColorTable(CNODE_S);
 
     s_P4PrintPainter->setPen(QXFIGCOLOR(color));
     s_P4PrintPainter->setBrush(QXFIGCOLOR(color));
@@ -381,9 +383,9 @@ static void P4Print_print_seunstablenode(double _x, double _y)
     y = (int)_y;
 
     if (s_P4PrintBlackWhite)
-        color = g_printColorTable[bgColours::CFOREGROUND];
+        color = printColorTable(bgColours::CFOREGROUND);
     else
-        color = g_printColorTable[CNODE_U];
+        color = printColorTable(CNODE_U);
 
     s_P4PrintPainter->setPen(QXFIGCOLOR(color));
     s_P4PrintPainter->setBrush(QXFIGCOLOR(color));
@@ -414,9 +416,9 @@ static void P4Print_print_degen(double _x, double _y)
     // print cross:
 
     if (s_P4PrintBlackWhite)
-        color = g_printColorTable[bgColours::CFOREGROUND];
+        color = printColorTable(bgColours::CFOREGROUND);
     else
-        color = g_printColorTable[CDEGEN];
+        color = printColorTable(CDEGEN);
 
     QPen p = QPen(QXFIGCOLOR(color), i);
     s_P4PrintPainter->setPen(p);
@@ -432,11 +434,13 @@ static void P4Print_print_elips(double x0, double y0, double a, double b,
                                 int color, bool dotted,
                                 struct P4POLYLINES *ellipse)
 {
-    color = g_printColorTable[color];
+    int color2;
     if (s_P4PrintBlackWhite)
-        color = g_printColorTable[bgColours::CFOREGROUND];
+        color2 = printColorTable(bgColours::CFOREGROUND);
+    else
+        color2 = printColorTable(color);
 
-    QPen p = QPen(QXFIGCOLOR(color), s_P4PrintLineWidth);
+    QPen p = QPen(QXFIGCOLOR(color2), s_P4PrintLineWidth);
     p.setCapStyle(Qt::RoundCap);
     s_P4PrintPainter->setPen(p);
 
@@ -462,9 +466,9 @@ static void P4Print_print_line(double _x0, double _y0, double _x1, double _y1,
 {
     int x0, y0, x1, y1;
 
-    color = g_printColorTable[color];
+    color = printColorTable(color);
     if (s_P4PrintBlackWhite)
-        color = g_printColorTable[bgColours::CFOREGROUND];
+        color = printColorTable(bgColours::CFOREGROUND);
 
     x0 = (int)_x0;
     x1 = (int)_x1;
@@ -488,7 +492,7 @@ static void P4Print_print_point(double _x0, double _y0, int color)
 
     if (s_P4PrintBlackWhite)
         color = bgColours::CFOREGROUND;
-    color = g_printColorTable[color];
+    color = printColorTable(color);
 
     x0 = (int)_x0;
     y0 = (int)_y0;
@@ -550,7 +554,7 @@ void prepareP4Printing(int w, int h, bool isblackwhite, QPainter *p4paint,
 
     p4paint->fillRect(
         0, 0, w, h,
-        QBrush(QXFIGCOLOR(g_printColorTable[bgColours::CBACKGROUND])));
+        QBrush(QXFIGCOLOR(printColorTable(bgColours::CBACKGROUND))));
 }
 
 void finishP4Printing(void)

--- a/src-gui/p4/print_bitmap.cpp
+++ b/src-gui/p4/print_bitmap.cpp
@@ -67,7 +67,10 @@ static void P4Print_print_saddle(double _x, double _y)
     x = (int)_x;
     y = (int)_y;
 
-    color = g_printColorTable[s_P4PrintBlackWhite ? CFOREGROUND : CSADDLE];
+    if (s_P4PrintBlackWhite)
+        color = g_printColorTable[bgColours::CFOREGROUND];
+    else
+        color = g_printColorTable[CSADDLE];
 
     s_P4PrintPainter->setPen(QXFIGCOLOR(color));
     s_P4PrintPainter->setBrush(QXFIGCOLOR(color));
@@ -87,7 +90,10 @@ static void P4Print_print_stablenode(double _x, double _y)
     x = (int)_x;
     y = (int)_y;
 
-    color = g_printColorTable[s_P4PrintBlackWhite ? CFOREGROUND : CNODE_S];
+    if (s_P4PrintBlackWhite)
+        color = g_printColorTable[bgColours::CFOREGROUND];
+    else
+        color = g_printColorTable[CNODE_S];
 
     s_P4PrintPainter->setPen(QXFIGCOLOR(color));
     s_P4PrintPainter->setBrush(QXFIGCOLOR(color));
@@ -106,7 +112,10 @@ static void P4Print_print_unstablenode(double _x, double _y)
     x = (int)_x;
     y = (int)_y;
 
-    color = g_printColorTable[s_P4PrintBlackWhite ? CFOREGROUND : CNODE_U];
+    if (s_P4PrintBlackWhite)
+        color = g_printColorTable[bgColours::CFOREGROUND];
+    else
+        color = g_printColorTable[CNODE_U];
 
     s_P4PrintPainter->setPen(QXFIGCOLOR(color));
     s_P4PrintPainter->setBrush(QXFIGCOLOR(color));
@@ -125,8 +134,10 @@ static void P4Print_print_stableweakfocus(double _x, double _y)
 
     x = (int)_x;
     y = (int)_y;
-    color =
-        g_printColorTable[s_P4PrintBlackWhite ? CFOREGROUND : CWEAK_FOCUS_S];
+    if (s_P4PrintBlackWhite)
+        color = g_printColorTable[bgColours::CFOREGROUND];
+    else
+        color = g_printColorTable[CWEAK_FOCUS_S];
 
     s_P4PrintPainter->setPen(QXFIGCOLOR(color));
     s_P4PrintPainter->setBrush(QXFIGCOLOR(color));
@@ -150,8 +161,10 @@ static void P4Print_print_unstableweakfocus(double _x, double _y)
 
     x = (int)_x;
     y = (int)_y;
-    color =
-        g_printColorTable[s_P4PrintBlackWhite ? CFOREGROUND : CWEAK_FOCUS_U];
+    if (s_P4PrintBlackWhite)
+        color = g_printColorTable[bgColours::CFOREGROUND];
+    else
+        color = g_printColorTable[CWEAK_FOCUS_U];
 
     s_P4PrintPainter->setPen(QXFIGCOLOR(color));
     s_P4PrintPainter->setBrush(QXFIGCOLOR(color));
@@ -176,7 +189,10 @@ static void P4Print_print_weakfocus(double _x, double _y)
     x = (int)_x;
     y = (int)_y;
 
-    color = g_printColorTable[s_P4PrintBlackWhite ? CFOREGROUND : CWEAK_FOCUS];
+    if (s_P4PrintBlackWhite)
+        color = g_printColorTable[bgColours::CFOREGROUND];
+    else
+        color = g_printColorTable[CWEAK_FOCUS];
 
     s_P4PrintPainter->setPen(QXFIGCOLOR(color));
     s_P4PrintPainter->setBrush(QXFIGCOLOR(color));
@@ -201,7 +217,10 @@ static void P4Print_print_center(double _x, double _y)
     x = (int)_x;
     y = (int)_y;
 
-    color = g_printColorTable[s_P4PrintBlackWhite ? CFOREGROUND : CCENTER];
+    if (s_P4PrintBlackWhite)
+        color = g_printColorTable[bgColours::CFOREGROUND];
+    else
+        color = g_printColorTable[CCENTER];
 
     s_P4PrintPainter->setPen(QXFIGCOLOR(color));
     s_P4PrintPainter->setBrush(QXFIGCOLOR(color));
@@ -226,8 +245,10 @@ static void P4Print_print_stablestrongfocus(double _x, double _y)
     x = (int)_x;
     y = (int)_y;
 
-    color =
-        g_printColorTable[s_P4PrintBlackWhite ? CFOREGROUND : CSTRONG_FOCUS_S];
+    if (s_P4PrintBlackWhite)
+        color = g_printColorTable[bgColours::CFOREGROUND];
+    else
+        color = g_printColorTable[CSTRONG_FOCUS_S];
 
     s_P4PrintPainter->setPen(QXFIGCOLOR(color));
     s_P4PrintPainter->setBrush(QXFIGCOLOR(color));
@@ -251,8 +272,10 @@ static void P4Print_print_unstablestrongfocus(double _x, double _y)
     x = (int)_x; // seems to be necessary
     y = (int)_y;
 
-    color =
-        g_printColorTable[s_P4PrintBlackWhite ? CFOREGROUND : CSTRONG_FOCUS_U];
+    if (s_P4PrintBlackWhite)
+        color = g_printColorTable[bgColours::CFOREGROUND];
+    else
+        color = g_printColorTable[CSTRONG_FOCUS_U];
 
     s_P4PrintPainter->setPen(QXFIGCOLOR(color));
     s_P4PrintPainter->setBrush(QXFIGCOLOR(color));
@@ -277,7 +300,10 @@ static void P4Print_print_sesaddle(double _x, double _y)
     x = (int)_x;
     y = (int)_y;
 
-    color = g_printColorTable[s_P4PrintBlackWhite ? CFOREGROUND : CSADDLE];
+    if (s_P4PrintBlackWhite)
+        color = g_printColorTable[bgColours::CFOREGROUND];
+    else
+        color = g_printColorTable[CSADDLE];
 
     s_P4PrintPainter->setPen(QXFIGCOLOR(color));
     s_P4PrintPainter->setBrush(QXFIGCOLOR(color));
@@ -301,7 +327,10 @@ static void P4Print_print_sesaddlenode(double _x, double _y)
     x = (int)_x; // seems to be necessary
     y = (int)_y;
 
-    color = g_printColorTable[s_P4PrintBlackWhite ? CFOREGROUND : CSADDLE_NODE];
+    if (s_P4PrintBlackWhite)
+        color = g_printColorTable[bgColours::CFOREGROUND];
+    else
+        color = g_printColorTable[CSADDLE_NODE];
 
     s_P4PrintPainter->setPen(QXFIGCOLOR(color));
     s_P4PrintPainter->setBrush(QXFIGCOLOR(color));
@@ -324,7 +353,10 @@ static void P4Print_print_sestablenode(double _x, double _y)
     x = (int)_x; // seems to be necessary
     y = (int)_y;
 
-    color = g_printColorTable[s_P4PrintBlackWhite ? CFOREGROUND : CNODE_S];
+    if (s_P4PrintBlackWhite)
+        color = g_printColorTable[bgColours::CFOREGROUND];
+    else
+        color = g_printColorTable[CNODE_S];
 
     s_P4PrintPainter->setPen(QXFIGCOLOR(color));
     s_P4PrintPainter->setBrush(QXFIGCOLOR(color));
@@ -348,7 +380,10 @@ static void P4Print_print_seunstablenode(double _x, double _y)
     x = (int)_x; // seems to be necessary
     y = (int)_y;
 
-    color = g_printColorTable[s_P4PrintBlackWhite ? CFOREGROUND : CNODE_U];
+    if (s_P4PrintBlackWhite)
+        color = g_printColorTable[bgColours::CFOREGROUND];
+    else
+        color = g_printColorTable[CNODE_U];
 
     s_P4PrintPainter->setPen(QXFIGCOLOR(color));
     s_P4PrintPainter->setBrush(QXFIGCOLOR(color));
@@ -378,7 +413,10 @@ static void P4Print_print_degen(double _x, double _y)
 
     // print cross:
 
-    color = g_printColorTable[s_P4PrintBlackWhite ? CFOREGROUND : CDEGEN];
+    if (s_P4PrintBlackWhite)
+        color = g_printColorTable[bgColours::CFOREGROUND];
+    else
+        color = g_printColorTable[CDEGEN];
 
     QPen p = QPen(QXFIGCOLOR(color), i);
     s_P4PrintPainter->setPen(p);
@@ -396,7 +434,7 @@ static void P4Print_print_elips(double x0, double y0, double a, double b,
 {
     color = g_printColorTable[color];
     if (s_P4PrintBlackWhite)
-        color = g_printColorTable[CFOREGROUND];
+        color = g_printColorTable[bgColours::CFOREGROUND];
 
     QPen p = QPen(QXFIGCOLOR(color), s_P4PrintLineWidth);
     p.setCapStyle(Qt::RoundCap);
@@ -426,7 +464,7 @@ static void P4Print_print_line(double _x0, double _y0, double _x1, double _y1,
 
     color = g_printColorTable[color];
     if (s_P4PrintBlackWhite)
-        color = g_printColorTable[CFOREGROUND];
+        color = g_printColorTable[bgColours::CFOREGROUND];
 
     x0 = (int)_x0;
     x1 = (int)_x1;
@@ -449,7 +487,7 @@ static void P4Print_print_point(double _x0, double _y0, int color)
     int y0;
 
     if (s_P4PrintBlackWhite)
-        color = CFOREGROUND;
+        color = bgColours::CFOREGROUND;
     color = g_printColorTable[color];
 
     x0 = (int)_x0;
@@ -510,8 +548,9 @@ void prepareP4Printing(int w, int h, bool isblackwhite, QPainter *p4paint,
 
     s_LastP4Printcolor = -1;
 
-    p4paint->fillRect(0, 0, w, h,
-                      QBrush(QXFIGCOLOR(g_printColorTable[CBACKGROUND])));
+    p4paint->fillRect(
+        0, 0, w, h,
+        QBrush(QXFIGCOLOR(g_printColorTable[bgColours::CBACKGROUND])));
 }
 
 void finishP4Printing(void)

--- a/src-gui/p4/print_bitmap.h
+++ b/src-gui/p4/print_bitmap.h
@@ -24,8 +24,7 @@
 
 #include <QPainter>
 
-extern int g_printColorTable[NUMXFIGCOLORS];
-
+int printColorTable(int color);
 void prepareP4Printing(int w, int h, bool isblackwhite, QPainter *p4paint,
                        int linewidth, int symbolwidth);
 void finishP4Printing(void);

--- a/src-gui/p4/print_postscript.cpp
+++ b/src-gui/p4/print_postscript.cpp
@@ -34,7 +34,11 @@ static bool s_PSBlackWhitePrint = true;
 
 static QFile *s_PSFile = nullptr;
 static QTextStream s_PSFileStream;
+static int s_PSW = 0;
+static int s_PSH = 0;
 
+
+static void ps_print_line(double x0, double y0, double x1, double y1, int color);
 // ---------------------------------------------------------------------------------------
 
 static void ps_print_comment(QString s)
@@ -50,10 +54,10 @@ static void ps_print_saddle(double x, double y)
         QString s;
         if (s_PSBlackWhitePrint)
             s.sprintf("col%d %f %f box\n",
-                      g_printColorTable[bgColours::CFOREGROUND], (float)x,
+                      printColorTable(bgColours::CFOREGROUND), (float)x,
                       (float)y);
         else
-            s.sprintf("col%d %f %f box\n", g_printColorTable[CSADDLE], (float)x,
+            s.sprintf("col%d %f %f box\n", printColorTable(CSADDLE), (float)x,
                       (float)y);
         s_PSFileStream << s;
     }
@@ -65,10 +69,10 @@ static void ps_print_stablenode(double x, double y)
         QString s;
         if (s_PSBlackWhitePrint)
             s.sprintf("col%d %f %f box\n",
-                      g_printColorTable[bgColours::CFOREGROUND], (float)x,
+                      printColorTable(bgColours::CFOREGROUND), (float)x,
                       (float)y);
         else
-            s.sprintf("col%d %f %f box\n", g_printColorTable[CNODE_S], (float)x,
+            s.sprintf("col%d %f %f box\n", printColorTable(CNODE_S), (float)x,
                       (float)y);
         s_PSFileStream << s;
     }
@@ -80,10 +84,10 @@ static void ps_print_unstablenode(double x, double y)
         QString s;
         if (s_PSBlackWhitePrint)
             s.sprintf("col%d %f %f box\n",
-                      g_printColorTable[bgColours::CFOREGROUND], (float)x,
+                      printColorTable(bgColours::CFOREGROUND), (float)x,
                       (float)y);
         else
-            s.sprintf("col%d %f %f box\n", g_printColorTable[CNODE_U], (float)x,
+            s.sprintf("col%d %f %f box\n", printColorTable(CNODE_U), (float)x,
                       (float)y);
         s_PSFileStream << s;
     }
@@ -95,10 +99,10 @@ static void ps_print_stableweakfocus(double x, double y)
         QString s;
         if (s_PSBlackWhitePrint)
             s.sprintf("col%d %f %f diamond\n",
-                      g_printColorTable[bgColours::CFOREGROUND], (float)x,
+                      printColorTable(bgColours::CFOREGROUND), (float)x,
                       (float)y);
         else
-            s.sprintf("col%d %f %f diamond\n", g_printColorTable[CWEAK_FOCUS_S],
+            s.sprintf("col%d %f %f diamond\n", printColorTable(CWEAK_FOCUS_S),
                       (float)x, (float)y);
         s_PSFileStream << s;
     }
@@ -110,10 +114,10 @@ static void ps_print_unstableweakfocus(double x, double y)
         QString s;
         if (s_PSBlackWhitePrint)
             s.sprintf("col%d %f %f diamond\n",
-                      g_printColorTable[bgColours::CFOREGROUND], (float)x,
+                      printColorTable(bgColours::CFOREGROUND), (float)x,
                       (float)y);
         else
-            s.sprintf("col%d %f %f diamond\n", g_printColorTable[CWEAK_FOCUS_U],
+            s.sprintf("col%d %f %f diamond\n", printColorTable(CWEAK_FOCUS_U),
                       (float)x, (float)y);
         s_PSFileStream << s;
     }
@@ -125,10 +129,10 @@ static void ps_print_weakfocus(double x, double y)
         QString s;
         if (s_PSBlackWhitePrint)
             s.sprintf("col%d %f %f diamond\n",
-                      g_printColorTable[bgColours::CFOREGROUND], (float)x,
+                      printColorTable(bgColours::CFOREGROUND), (float)x,
                       (float)y);
         else
-            s.sprintf("col%d %f %f diamond\n", g_printColorTable[CWEAK_FOCUS],
+            s.sprintf("col%d %f %f diamond\n", printColorTable(CWEAK_FOCUS),
                       (float)x, (float)y);
         s_PSFileStream << s;
     }
@@ -140,10 +144,10 @@ static void ps_print_center(double x, double y)
         QString s;
         if (s_PSBlackWhitePrint)
             s.sprintf("col%d %f %f diamond\n",
-                      g_printColorTable[bgColours::CFOREGROUND], (float)x,
+                      printColorTable(bgColours::CFOREGROUND), (float)x,
                       (float)y);
         else
-            s.sprintf("col%d %f %f diamond\n", g_printColorTable[CCENTER],
+            s.sprintf("col%d %f %f diamond\n", printColorTable(CCENTER),
                       (float)x, (float)y);
         s_PSFileStream << s;
     }
@@ -155,11 +159,11 @@ static void ps_print_stablestrongfocus(double x, double y)
         QString s;
         if (s_PSBlackWhitePrint)
             s.sprintf("col%d %f %f diamond\n",
-                      g_printColorTable[bgColours::CFOREGROUND], (float)x,
+                      printColorTable(bgColours::CFOREGROUND), (float)x,
                       (float)y);
         else
             s.sprintf("col%d %f %f diamond\n",
-                      g_printColorTable[CSTRONG_FOCUS_S], (float)x, (float)y);
+                      printColorTable(CSTRONG_FOCUS_S), (float)x, (float)y);
         s_PSFileStream << s;
     }
 }
@@ -170,11 +174,11 @@ static void ps_print_unstablestrongfocus(double x, double y)
         QString s;
         if (s_PSBlackWhitePrint)
             s.sprintf("col%d %f %f diamond\n",
-                      g_printColorTable[bgColours::CFOREGROUND], (float)x,
+                      printColorTable(bgColours::CFOREGROUND), (float)x,
                       (float)y);
         else
             s.sprintf("col%d %f %f diamond\n",
-                      g_printColorTable[CSTRONG_FOCUS_U], (float)x, (float)y);
+                      printColorTable(CSTRONG_FOCUS_U), (float)x, (float)y);
         s_PSFileStream << s;
     }
 }
@@ -185,10 +189,10 @@ static void ps_print_sesaddle(double x, double y)
         QString s;
         if (s_PSBlackWhitePrint)
             s.sprintf("col%d %f %f triangle\n",
-                      g_printColorTable[bgColours::CFOREGROUND], (float)x,
+                      printColorTable(bgColours::CFOREGROUND), (float)x,
                       (float)y);
         else
-            s.sprintf("col%d %f %f triangle\n", g_printColorTable[CSADDLE],
+            s.sprintf("col%d %f %f triangle\n", printColorTable(CSADDLE),
                       (float)x, (float)y);
         s_PSFileStream << s;
     }
@@ -200,10 +204,10 @@ static void ps_print_sesaddlenode(double x, double y)
         QString s;
         if (s_PSBlackWhitePrint)
             s.sprintf("col%d %f %f triangle\n",
-                      g_printColorTable[bgColours::CFOREGROUND], (float)x,
+                      printColorTable(bgColours::CFOREGROUND), (float)x,
                       (float)y);
         else
-            s.sprintf("col%d %f %f triangle\n", g_printColorTable[CSADDLE_NODE],
+            s.sprintf("col%d %f %f triangle\n", printColorTable(CSADDLE_NODE),
                       (float)x, (float)y);
         s_PSFileStream << s;
     }
@@ -215,10 +219,10 @@ static void ps_print_sestablenode(double x, double y)
         QString s;
         if (s_PSBlackWhitePrint)
             s.sprintf("col%d %f %f triangle\n",
-                      g_printColorTable[bgColours::CFOREGROUND], (float)x,
+                      printColorTable(bgColours::CFOREGROUND), (float)x,
                       (float)y);
         else
-            s.sprintf("col%d %f %f triangle\n", g_printColorTable[CNODE_S],
+            s.sprintf("col%d %f %f triangle\n", printColorTable(CNODE_S),
                       (float)x, (float)y);
         s_PSFileStream << s;
     }
@@ -230,10 +234,10 @@ static void ps_print_seunstablenode(double x, double y)
         QString s;
         if (s_PSBlackWhitePrint)
             s.sprintf("col%d %f %f triangle\n",
-                      g_printColorTable[bgColours::CFOREGROUND], (float)x,
+                      printColorTable(bgColours::CFOREGROUND), (float)x,
                       (float)y);
         else
-            s.sprintf("col%d %f %f triangle\n", g_printColorTable[CNODE_U],
+            s.sprintf("col%d %f %f triangle\n", printColorTable(CNODE_U),
                       (float)x, (float)y);
         s_PSFileStream << s;
     }
@@ -247,14 +251,14 @@ static void ps_print_degen(double x, double y)
             s.sprintf("LW 2.6 mul setlinewidth\n"
                       "col%d %f %f cross\n"
                       "LW setlinewidth\n",
-                      g_printColorTable[bgColours::CFOREGROUND], (float)x,
+                      printColorTable(bgColours::CFOREGROUND), (float)x,
                       (float)y);
         } else {
             if (s_PSBlackWhitePrint) {
                 s.sprintf("LW 2.6 mul setlinewidth\n"
                           "col%d %f %f cross\n"
                           "LW setlinewidth\n",
-                          g_printColorTable[CDEGEN], (float)x, (float)y);
+                          printColorTable(CDEGEN), (float)x, (float)y);
             }
             s_PSFileStream << s;
         }
@@ -262,47 +266,51 @@ static void ps_print_degen(double x, double y)
 }
 
 static void ps_print_elips(double x0, double y0, double a, double b, int color,
-                           bool dotted, struct P4POLYLINES *)
+                           bool dotted, struct P4POLYLINES *ellipse)
 {
     double t, h;
     QString s;
 
     // we do not use the precompiled form of the ellipse printing.  Here, it
-    // is
-    // not necessary,
-    // since the PS command for drawing ellipses works just fine.
-
-    color = g_printColorTable[color];
+    // is not necessary, since the PS command for drawing ellipses works just fine.
 
     if (s_PSFile != nullptr) {
         if (dotted)
             s_PSFileStream << "gsave\n";
 
         if (s_PSBlackWhitePrint)
-            s.sprintf("col%d\n", g_printColorTable[bgColours::CFOREGROUND]);
+            s.sprintf("col%d\n", printColorTable(bgColours::CFOREGROUND));
         else
-            s.sprintf("col%d\n", g_printColorTable[color]);
+            s.sprintf("col%d\n", printColorTable(color));
 
         s_PSFileStream << s;
         s_PSFileStream << "newpath\n";
 
-        s.sprintf("%f %f moveto\n", (float)(x0 + a), (float)y0);
-        s_PSFileStream << s;
-        h = PI / 100;
-        for (t = h; t < TWOPI; t += h) {
-            s.sprintf("%f %f lineto \n", (float)(x0 + a * cos(t)),
-                      (float)(y0 + b * sin(t)));
+        if (x0-a>=0 && x0+a<s_PSW && y0-b>=0 && y0+b<s_PSH) {
+            // full elipse visible
+            s.sprintf("%f %f moveto\n", (float)(x0 + a), (float)y0);
             s_PSFileStream << s;
-        }
+            h = PI / 100;
+            for (t = h; t < TWOPI; t += h) {
+                s.sprintf("%f %f lineto \n", (float)(x0 + a * cos(t)),
+                          (float)(y0 + b * sin(t)));
+                s_PSFileStream << s;
+            }
 
-        s_PSFileStream << "closepath\n";
-        s_PSFileStream << "LW setlinewidth\n";
-        if (dotted) {
-            s_PSFileStream << "[DS ] 0 setdash\n";
-        }
-        s_PSFileStream << "stroke\n";
-        if (dotted) {
-            s_PSFileStream << "grestore\n";
+            s_PSFileStream << "closepath\n";
+            s_PSFileStream << "LW setlinewidth\n";
+            if (dotted) {
+                s_PSFileStream << "[DS ) 0 setdash\n";
+            }
+            s_PSFileStream << "stroke\n";
+            if (dotted) {
+                s_PSFileStream << "grestore\n";
+            }
+        } else {
+            while (ellipse != nullptr) {
+                ps_print_line(ellipse->x1,ellipse->y1,ellipse->x2,ellipse->y2,color);
+                ellipse = ellipse->next;
+            }
         }
     }
 }
@@ -317,11 +325,11 @@ static void ps_print_line(double x0, double y0, double x1, double y1, int color)
         if (s_PSBlackWhitePrint) {
             s.sprintf("%f %f moveto\n%f %f lineto col%d stroke\n", (float)x0,
                       (float)y0, (float)x1, (float)y1,
-                      g_printColorTable[bgColours::CFOREGROUND]);
+                      printColorTable(bgColours::CFOREGROUND));
         } else {
             s.sprintf("%f %f moveto\n%f %f lineto col%d stroke\n", (float)x0,
                       (float)y0, (float)x1, (float)y1,
-                      g_printColorTable[color]);
+                      printColorTable(color));
         }
         s_PSFileStream << s;
     }
@@ -346,10 +354,10 @@ static void ps_print_point(double x0, double y0, int color)
         QString s;
         if (s_PSBlackWhitePrint)
             s.sprintf("col%d %f %f dot\n",
-                      g_printColorTable[bgColours::CFOREGROUND], (float)x0,
+                      printColorTable(bgColours::CFOREGROUND), (float)x0,
                       (float)y0);
         else
-            s.sprintf("col%d %f %f dot\n", g_printColorTable[color], (float)x0,
+            s.sprintf("col%d %f %f dot\n", printColorTable(color), (float)x0,
                       (float)y0);
         s_PSFileStream << s;
     }
@@ -361,6 +369,8 @@ void preparePostscriptPrinting(int x0, int y0, int w, int h, bool iszoom,
                                bool isblackwhite, int resolution, int linewidth,
                                int symbolwidth)
 {
+    s_PSW = w;
+    s_PSH = h;
     QString s;
     double bbx0, bby0, bbw, bbh, bbx1, bby1;
     double scalefactor;
@@ -552,6 +562,20 @@ void preparePostscriptPrinting(int x0, int y0, int w, int h, bool iszoom,
                   "[] 0 setdash\n",
                   w, h);
         s_PSFileStream << s;
+
+        if (!bgColours::PRINT_WHITE_BG) {
+          s.sprintf("%% Fill background with black rectangle:\n"
+            "newpath\n"
+            "0 0 moveto\n"
+            "%d 0 lineto\n"
+            "%d %d lineto\n"
+            "0 %d lineto\n"
+            "closepath\n"
+            "col0\n"
+            "fill\n",
+            w,w,h,h);
+          s_PSFileStream << s;
+        }
 
         if (iszoom || g_VFResults.typeofview_ == TYPEOFVIEW_PLANE) {
             s_PSFileStream << "frame\n";

--- a/src-gui/p4/print_postscript.cpp
+++ b/src-gui/p4/print_postscript.cpp
@@ -48,10 +48,13 @@ static void ps_print_saddle(double x, double y)
 {
     if (s_PSFile != nullptr) {
         QString s;
-        s.sprintf("col%d %f %f box\n",
-                  s_PSBlackWhitePrint ? g_printColorTable[CFOREGROUND]
-                                      : g_printColorTable[CSADDLE],
-                  (float)x, (float)y);
+        if (s_PSBlackWhitePrint)
+            s.sprintf("col%d %f %f box\n",
+                      g_printColorTable[bgColours::CFOREGROUND], (float)x,
+                      (float)y);
+        else
+            s.sprintf("col%d %f %f box\n", g_printColorTable[CSADDLE], (float)x,
+                      (float)y);
         s_PSFileStream << s;
     }
 }
@@ -60,10 +63,13 @@ static void ps_print_stablenode(double x, double y)
 {
     if (s_PSFile != nullptr) {
         QString s;
-        s.sprintf("col%d %f %f box\n",
-                  s_PSBlackWhitePrint ? g_printColorTable[CFOREGROUND]
-                                      : g_printColorTable[CNODE_S],
-                  (float)x, (float)y);
+        if (s_PSBlackWhitePrint)
+            s.sprintf("col%d %f %f box\n",
+                      g_printColorTable[bgColours::CFOREGROUND], (float)x,
+                      (float)y);
+        else
+            s.sprintf("col%d %f %f box\n", g_printColorTable[CNODE_S], (float)x,
+                      (float)y);
         s_PSFileStream << s;
     }
 }
@@ -72,10 +78,13 @@ static void ps_print_unstablenode(double x, double y)
 {
     if (s_PSFile != nullptr) {
         QString s;
-        s.sprintf("col%d %f %f box\n",
-                  s_PSBlackWhitePrint ? g_printColorTable[CFOREGROUND]
-                                      : g_printColorTable[CNODE_U],
-                  (float)x, (float)y);
+        if (s_PSBlackWhitePrint)
+            s.sprintf("col%d %f %f box\n",
+                      g_printColorTable[bgColours::CFOREGROUND], (float)x,
+                      (float)y);
+        else
+            s.sprintf("col%d %f %f box\n", g_printColorTable[CNODE_U], (float)x,
+                      (float)y);
         s_PSFileStream << s;
     }
 }
@@ -84,10 +93,13 @@ static void ps_print_stableweakfocus(double x, double y)
 {
     if (s_PSFile != nullptr) {
         QString s;
-        s.sprintf("col%d %f %f diamond\n",
-                  s_PSBlackWhitePrint ? g_printColorTable[CFOREGROUND]
-                                      : g_printColorTable[CWEAK_FOCUS_S],
-                  (float)x, (float)y);
+        if (s_PSBlackWhitePrint)
+            s.sprintf("col%d %f %f diamond\n",
+                      g_printColorTable[bgColours::CFOREGROUND], (float)x,
+                      (float)y);
+        else
+            s.sprintf("col%d %f %f diamond\n", g_printColorTable[CWEAK_FOCUS_S],
+                      (float)x, (float)y);
         s_PSFileStream << s;
     }
 }
@@ -96,10 +108,13 @@ static void ps_print_unstableweakfocus(double x, double y)
 {
     if (s_PSFile != nullptr) {
         QString s;
-        s.sprintf("col%d %f %f diamond\n",
-                  s_PSBlackWhitePrint ? g_printColorTable[CFOREGROUND]
-                                      : g_printColorTable[CWEAK_FOCUS_U],
-                  (float)x, (float)y);
+        if (s_PSBlackWhitePrint)
+            s.sprintf("col%d %f %f diamond\n",
+                      g_printColorTable[bgColours::CFOREGROUND], (float)x,
+                      (float)y);
+        else
+            s.sprintf("col%d %f %f diamond\n", g_printColorTable[CWEAK_FOCUS_U],
+                      (float)x, (float)y);
         s_PSFileStream << s;
     }
 }
@@ -108,10 +123,13 @@ static void ps_print_weakfocus(double x, double y)
 {
     if (s_PSFile != nullptr) {
         QString s;
-        s.sprintf("col%d %f %f diamond\n",
-                  s_PSBlackWhitePrint ? g_printColorTable[CFOREGROUND]
-                                      : g_printColorTable[CWEAK_FOCUS],
-                  (float)x, (float)y);
+        if (s_PSBlackWhitePrint)
+            s.sprintf("col%d %f %f diamond\n",
+                      g_printColorTable[bgColours::CFOREGROUND], (float)x,
+                      (float)y);
+        else
+            s.sprintf("col%d %f %f diamond\n", g_printColorTable[CWEAK_FOCUS],
+                      (float)x, (float)y);
         s_PSFileStream << s;
     }
 }
@@ -120,10 +138,13 @@ static void ps_print_center(double x, double y)
 {
     if (s_PSFile != nullptr) {
         QString s;
-        s.sprintf("col%d %f %f diamond\n",
-                  s_PSBlackWhitePrint ? g_printColorTable[CFOREGROUND]
-                                      : g_printColorTable[CCENTER],
-                  (float)x, (float)y);
+        if (s_PSBlackWhitePrint)
+            s.sprintf("col%d %f %f diamond\n",
+                      g_printColorTable[bgColours::CFOREGROUND], (float)x,
+                      (float)y);
+        else
+            s.sprintf("col%d %f %f diamond\n", g_printColorTable[CCENTER],
+                      (float)x, (float)y);
         s_PSFileStream << s;
     }
 }
@@ -132,10 +153,13 @@ static void ps_print_stablestrongfocus(double x, double y)
 {
     if (s_PSFile != nullptr) {
         QString s;
-        s.sprintf("col%d %f %f diamond\n",
-                  s_PSBlackWhitePrint ? g_printColorTable[CFOREGROUND]
-                                      : g_printColorTable[CSTRONG_FOCUS_S],
-                  (float)x, (float)y);
+        if (s_PSBlackWhitePrint)
+            s.sprintf("col%d %f %f diamond\n",
+                      g_printColorTable[bgColours::CFOREGROUND], (float)x,
+                      (float)y);
+        else
+            s.sprintf("col%d %f %f diamond\n",
+                      g_printColorTable[CSTRONG_FOCUS_S], (float)x, (float)y);
         s_PSFileStream << s;
     }
 }
@@ -144,10 +168,13 @@ static void ps_print_unstablestrongfocus(double x, double y)
 {
     if (s_PSFile != nullptr) {
         QString s;
-        s.sprintf("col%d %f %f diamond\n",
-                  s_PSBlackWhitePrint ? g_printColorTable[CFOREGROUND]
-                                      : g_printColorTable[CSTRONG_FOCUS_U],
-                  (float)x, (float)y);
+        if (s_PSBlackWhitePrint)
+            s.sprintf("col%d %f %f diamond\n",
+                      g_printColorTable[bgColours::CFOREGROUND], (float)x,
+                      (float)y);
+        else
+            s.sprintf("col%d %f %f diamond\n",
+                      g_printColorTable[CSTRONG_FOCUS_U], (float)x, (float)y);
         s_PSFileStream << s;
     }
 }
@@ -156,10 +183,13 @@ static void ps_print_sesaddle(double x, double y)
 {
     if (s_PSFile != nullptr) {
         QString s;
-        s.sprintf("col%d %f %f triangle\n",
-                  s_PSBlackWhitePrint ? g_printColorTable[CFOREGROUND]
-                                      : g_printColorTable[CSADDLE],
-                  (float)x, (float)y);
+        if (s_PSBlackWhitePrint)
+            s.sprintf("col%d %f %f triangle\n",
+                      g_printColorTable[bgColours::CFOREGROUND], (float)x,
+                      (float)y);
+        else
+            s.sprintf("col%d %f %f triangle\n", g_printColorTable[CSADDLE],
+                      (float)x, (float)y);
         s_PSFileStream << s;
     }
 }
@@ -168,10 +198,13 @@ static void ps_print_sesaddlenode(double x, double y)
 {
     if (s_PSFile != nullptr) {
         QString s;
-        s.sprintf("col%d %f %f triangle\n",
-                  s_PSBlackWhitePrint ? g_printColorTable[CFOREGROUND]
-                                      : g_printColorTable[CSADDLE_NODE],
-                  (float)x, (float)y);
+        if (s_PSBlackWhitePrint)
+            s.sprintf("col%d %f %f triangle\n",
+                      g_printColorTable[bgColours::CFOREGROUND], (float)x,
+                      (float)y);
+        else
+            s.sprintf("col%d %f %f triangle\n", g_printColorTable[CSADDLE_NODE],
+                      (float)x, (float)y);
         s_PSFileStream << s;
     }
 }
@@ -180,10 +213,13 @@ static void ps_print_sestablenode(double x, double y)
 {
     if (s_PSFile != nullptr) {
         QString s;
-        s.sprintf("col%d %f %f triangle\n",
-                  s_PSBlackWhitePrint ? g_printColorTable[CFOREGROUND]
-                                      : g_printColorTable[CNODE_S],
-                  (float)x, (float)y);
+        if (s_PSBlackWhitePrint)
+            s.sprintf("col%d %f %f triangle\n",
+                      g_printColorTable[bgColours::CFOREGROUND], (float)x,
+                      (float)y);
+        else
+            s.sprintf("col%d %f %f triangle\n", g_printColorTable[CNODE_S],
+                      (float)x, (float)y);
         s_PSFileStream << s;
     }
 }
@@ -192,10 +228,13 @@ static void ps_print_seunstablenode(double x, double y)
 {
     if (s_PSFile != nullptr) {
         QString s;
-        s.sprintf("col%d %f %f triangle\n",
-                  s_PSBlackWhitePrint ? g_printColorTable[CFOREGROUND]
-                                      : g_printColorTable[CNODE_U],
-                  (float)x, (float)y);
+        if (s_PSBlackWhitePrint)
+            s.sprintf("col%d %f %f triangle\n",
+                      g_printColorTable[bgColours::CFOREGROUND], (float)x,
+                      (float)y);
+        else
+            s.sprintf("col%d %f %f triangle\n", g_printColorTable[CNODE_U],
+                      (float)x, (float)y);
         s_PSFileStream << s;
     }
 }
@@ -204,13 +243,21 @@ static void ps_print_degen(double x, double y)
 {
     if (s_PSFile != nullptr) {
         QString s;
-        s.sprintf("LW 2.6 mul setlinewidth\n"
-                  "col%d %f %f cross\n"
-                  "LW setlinewidth\n",
-                  s_PSBlackWhitePrint ? g_printColorTable[CFOREGROUND]
-                                      : g_printColorTable[CDEGEN],
-                  (float)x, (float)y);
-        s_PSFileStream << s;
+        if (s_PSBlackWhitePrint) {
+            s.sprintf("LW 2.6 mul setlinewidth\n"
+                      "col%d %f %f cross\n"
+                      "LW setlinewidth\n",
+                      g_printColorTable[bgColours::CFOREGROUND], (float)x,
+                      (float)y);
+        } else {
+            if (s_PSBlackWhitePrint) {
+                s.sprintf("LW 2.6 mul setlinewidth\n"
+                          "col%d %f %f cross\n"
+                          "LW setlinewidth\n",
+                          g_printColorTable[CDEGEN], (float)x, (float)y);
+            }
+            s_PSFileStream << s;
+        }
     }
 }
 
@@ -220,7 +267,8 @@ static void ps_print_elips(double x0, double y0, double a, double b, int color,
     double t, h;
     QString s;
 
-    // we do not use the precompiled form of the ellipse printing.  Here, it is
+    // we do not use the precompiled form of the ellipse printing.  Here, it
+    // is
     // not necessary,
     // since the PS command for drawing ellipses works just fine.
 
@@ -230,8 +278,11 @@ static void ps_print_elips(double x0, double y0, double a, double b, int color,
         if (dotted)
             s_PSFileStream << "gsave\n";
 
-        s.sprintf("col%d\n",
-                  s_PSBlackWhitePrint ? g_printColorTable[CFOREGROUND] : color);
+        if (s_PSBlackWhitePrint)
+            s.sprintf("col%d\n", g_printColorTable[bgColours::CFOREGROUND]);
+        else
+            s.sprintf("col%d\n", g_printColorTable[color]);
+
         s_PSFileStream << s;
         s_PSFileStream << "newpath\n";
 
@@ -263,10 +314,15 @@ static void ps_print_line(double x0, double y0, double x1, double y1, int color)
 
     if (s_PSFile != nullptr) {
         QString s;
-        s.sprintf("%f %f moveto\n%f %f lineto col%d stroke\n", (float)x0,
-                  (float)y0, (float)x1, (float)y1,
-                  s_PSBlackWhitePrint ? g_printColorTable[CFOREGROUND]
-                                      : g_printColorTable[color]);
+        if (s_PSBlackWhitePrint) {
+            s.sprintf("%f %f moveto\n%f %f lineto col%d stroke\n", (float)x0,
+                      (float)y0, (float)x1, (float)y1,
+                      g_printColorTable[bgColours::CFOREGROUND]);
+        } else {
+            s.sprintf("%f %f moveto\n%f %f lineto col%d stroke\n", (float)x0,
+                      (float)y0, (float)x1, (float)y1,
+                      g_printColorTable[color]);
+        }
         s_PSFileStream << s;
     }
 }
@@ -278,7 +334,8 @@ static int s_lastpscolor = 0;
 static void ps_print_point(double x0, double y0, int color)
 {
     if (s_lastpsx0 == x0 && s_lastpsy0 == y0 && s_lastpscolor == color)
-        return; // just a small protection against big PS files: do not print
+        return; // just a small protection against big PS files: do not
+                // print
                 // series of the same points.
 
     s_lastpsx0 = x0;
@@ -287,10 +344,13 @@ static void ps_print_point(double x0, double y0, int color)
 
     if (s_PSFile != nullptr) {
         QString s;
-        s.sprintf("col%d %f %f dot\n",
-                  s_PSBlackWhitePrint ? g_printColorTable[CFOREGROUND]
-                                      : g_printColorTable[color],
-                  (float)x0, (float)y0);
+        if (s_PSBlackWhitePrint)
+            s.sprintf("col%d %f %f dot\n",
+                      g_printColorTable[bgColours::CFOREGROUND], (float)x0,
+                      (float)y0);
+        else
+            s.sprintf("col%d %f %f dot\n", g_printColorTable[color], (float)x0,
+                      (float)y0);
         s_PSFileStream << s;
     }
 }
@@ -370,7 +430,8 @@ void preparePostscriptPrinting(int x0, int y0, int w, int h, bool iszoom,
         title += " (zoom window)";
 
     if (s_PSFile != nullptr) {
-        // to calculate bounding box, we need to convert to point measurements
+        // to calculate bounding box, we need to convert to point
+        // measurements
         // (1 point = 1/72 inch)
 
         s.sprintf("%%!PS-Adobe-3.0 EPSF-3.0\n"
@@ -484,12 +545,12 @@ void preparePostscriptPrinting(int x0, int y0, int w, int h, bool iszoom,
                           "stroke\n"
                           "}bind def\n\n";
 
-        s.sprintf(
-            "%% Main Picture (local coordinates (x0,y0,x1,y1)=(0,0,%d,%d):\n"
-            "gsave\n"
-            "scaletransformation\n"
-            "[] 0 setdash\n",
-            w, h);
+        s.sprintf("%% Main Picture (local coordinates "
+                  "(x0,y0,x1,y1)=(0,0,%d,%d):\n"
+                  "gsave\n"
+                  "scaletransformation\n"
+                  "[] 0 setdash\n",
+                  w, h);
         s_PSFileStream << s;
 
         if (iszoom || g_VFResults.typeofview_ == TYPEOFVIEW_PLANE) {

--- a/src-gui/p4/print_xfig.cpp
+++ b/src-gui/p4/print_xfig.cpp
@@ -80,7 +80,7 @@ static void xfig_print_box(int x, int y, int color)
     y /= s_XFigResolution;
 
     if (s_XFigBlackWhitePrint)
-        color = g_printColorTable[CFOREGROUND];
+        color = g_printColorTable[bgColours::CFOREGROUND];
 
     /*
         object type     2   (=polyline)
@@ -122,7 +122,7 @@ static void xfig_print_diamond(int x, int y, int color)
         xfig_line_finish();
 
     if (s_XFigBlackWhitePrint)
-        color = g_printColorTable[CFOREGROUND];
+        color = g_printColorTable[bgColours::CFOREGROUND];
 
     x *= 1200;
     x /= s_XFigResolution;
@@ -152,7 +152,7 @@ static void xfig_print_triangle(int x, int y, int color)
         xfig_line_finish();
 
     if (s_XFigBlackWhitePrint)
-        color = g_printColorTable[CFOREGROUND];
+        color = g_printColorTable[bgColours::CFOREGROUND];
 
     x *= 1200;
     x /= s_XFigResolution;
@@ -185,7 +185,7 @@ static void xfig_print_cross(int x, int y, int color)
         xfig_line_finish();
 
     if (s_XFigBlackWhitePrint)
-        color = g_printColorTable[CFOREGROUND];
+        color = g_printColorTable[bgColours::CFOREGROUND];
 
     x *= 1200;
     x /= s_XFigResolution;
@@ -231,7 +231,7 @@ static void xfig_print_line(double _x0, double _y0, double _x1, double _y1,
     color = g_printColorTable[color];
 
     if (s_XFigBlackWhitePrint)
-        color = g_printColorTable[CFOREGROUND];
+        color = g_printColorTable[bgColours::CFOREGROUND];
 
     x0 = (int)_x0;
     y0 = (int)_y0;
@@ -432,7 +432,7 @@ static void xfig_print_point(double _x0, double _y0, int color)
     color = g_printColorTable[color];
 
     if (s_XFigBlackWhitePrint)
-        color = g_printColorTable[CFOREGROUND];
+        color = g_printColorTable[bgColours::CFOREGROUND];
 
     x0 = (int)_x0;
     y0 = (int)_y0;

--- a/src-gui/p4/print_xfig.cpp
+++ b/src-gui/p4/print_xfig.cpp
@@ -80,7 +80,7 @@ static void xfig_print_box(int x, int y, int color)
     y /= s_XFigResolution;
 
     if (s_XFigBlackWhitePrint)
-        color = g_printColorTable[bgColours::CFOREGROUND];
+        color = printColorTable(bgColours::CFOREGROUND);
 
     /*
         object type     2   (=polyline)
@@ -89,7 +89,7 @@ static void xfig_print_box(int x, int y, int color)
         thickness       1   (in 1/80 of an inch)
         pencolor        color
         fillcolor       color
-        depth           -1  (precedence over other objects !!!)
+        depth           0  (precedence over other objects !!!)
         penstyle        0   (unused in XFIG 3.1)
         areafill        46  (45 degree cross hatch)
         styleval        0.0 (only relevant for dashed lines)
@@ -102,7 +102,7 @@ static void xfig_print_box(int x, int y, int color)
     */
 
     QString s;
-    s.sprintf("2 2 0 1 %d %d -1 0 46 0.0 0 0 0 0 0 5\n", color, color);
+    s.sprintf("2 2 0 1 %d %d 0 0 46 0.0 0 0 0 0 0 5\n", color, color);
     s_XFigStream << s;
     s.sprintf("    %d %d %d %d %d %d %d %d %d %d\n", x + s_XFigSymbolWidth / 2,
               y - s_XFigSymbolWidth / 2, x + s_XFigSymbolWidth / 2,
@@ -122,7 +122,7 @@ static void xfig_print_diamond(int x, int y, int color)
         xfig_line_finish();
 
     if (s_XFigBlackWhitePrint)
-        color = g_printColorTable[bgColours::CFOREGROUND];
+        color = printColorTable(bgColours::CFOREGROUND);
 
     x *= 1200;
     x /= s_XFigResolution;
@@ -152,7 +152,7 @@ static void xfig_print_triangle(int x, int y, int color)
         xfig_line_finish();
 
     if (s_XFigBlackWhitePrint)
-        color = g_printColorTable[bgColours::CFOREGROUND];
+        color = printColorTable(bgColours::CFOREGROUND);
 
     x *= 1200;
     x /= s_XFigResolution;
@@ -185,7 +185,7 @@ static void xfig_print_cross(int x, int y, int color)
         xfig_line_finish();
 
     if (s_XFigBlackWhitePrint)
-        color = g_printColorTable[bgColours::CFOREGROUND];
+        color = printColorTable(bgColours::CFOREGROUND);
 
     x *= 1200;
     x /= s_XFigResolution;
@@ -228,10 +228,10 @@ static void xfig_print_line(double _x0, double _y0, double _x1, double _y1,
     if (s_XFigFile == nullptr)
         return;
 
-    color = g_printColorTable[color];
+    color = printColorTable(color);
 
     if (s_XFigBlackWhitePrint)
-        color = g_printColorTable[bgColours::CFOREGROUND];
+        color = printColorTable(bgColours::CFOREGROUND);
 
     x0 = (int)_x0;
     y0 = (int)_y0;
@@ -281,7 +281,7 @@ static void xfig_print_elips(double x0, double y0, double a, double b,
             thickness       ... (in 1/80 of an inch)
             pencolor        color
             fillcolor       color
-            depth           0   (no precedence over other objects)
+            depth           50   (no precedence over other objects)
             penstyle        0   (unused in XFIG 3.1)
             areafill        -1  (45 degree cross hatch)  USE 20 INSTEAD (FULL
            SATURATION OF THE COLOR)
@@ -311,9 +311,9 @@ static void xfig_print_elips(double x0, double y0, double a, double b,
         }
 
         QString s;
-        s.sprintf("1 1 %d %d %d %d 0 0 -1 %g 1 0.0 %d %d %d %d %d %d %d %d\n",
-                  linestyle, s_XFigLineWidth / 2, g_printColorTable[color],
-                  g_printColorTable[color], (float)styleval, (int)x0, (int)y0,
+        s.sprintf("1 1 %d %d %d %d 50 0 -1 %g 1 0.0 %d %d %d %d %d %d %d %d\n",
+                  linestyle, s_XFigLineWidth / 2, printColorTable(color),
+                  printColorTable(color), (float)styleval, (int)x0, (int)y0,
                   (int)a, (int)b, (int)x0, (int)y0, ((int)x0) + ((int)a),
                   (int)y0);
         s_XFigStream << s;
@@ -378,7 +378,7 @@ static void xfig_line_finish(void)
         thickness       thickness   (in 1/80 of an inch)
         pencolor        color
         fillcolor       7   (=white)
-        depth           0   (no precedence over other objects)
+        depth           50   (no precedence over other objects)
         penstyle        0   (unused in XFIG 3.1)
         areafill        -1  (no fill)
         styleval        0.0 (only relevant for dashed lines)
@@ -392,7 +392,7 @@ static void xfig_line_finish(void)
 
     if (s_XFigFile != nullptr) {
         QString s;
-        s.sprintf("2 1 0 %d %d  7 0 0 -1 0.0 0 1 -1 0 0 %d\n   ",
+        s.sprintf("2 1 0 %d %d 7 50 0 -1 0.0 0 1 -1 0 0 %d\n   ",
                   s_XFigLineWidth / 2, s_xfig_line_color,
                   s_xfig_line_numpoints);
         s_XFigStream << s;
@@ -429,10 +429,10 @@ static void xfig_print_point(double _x0, double _y0, int color)
     if (s_XFigFile == nullptr)
         return;
 
-    color = g_printColorTable[color];
+    color = printColorTable(color);
 
     if (s_XFigBlackWhitePrint)
-        color = g_printColorTable[bgColours::CFOREGROUND];
+        color = printColorTable(bgColours::CFOREGROUND);
 
     x0 = (int)_x0;
     y0 = (int)_y0;
@@ -451,7 +451,7 @@ static void xfig_print_point(double _x0, double _y0, int color)
         thickness       1   (in 1/80 of an inch)
         pencolor        color
         fillcolor       color
-        depth           0   (no precedence over other objects)
+        depth           50  (no precedence over other objects)
         penstyle        0   (unused in XFIG 3.1)
         areafill        46  (45 degree cross hatch)  USE 20 INSTEAD (FULL
        SATURATION OF THE COLOR)
@@ -469,7 +469,7 @@ static void xfig_print_point(double _x0, double _y0, int color)
     */
 
     QString s;
-    s.sprintf("1 3 0 1 %d %d 0 0 46 0.0 1 0.0 %d %d %d %d %d %d %d %d\n", color,
+    s.sprintf("1 3 0 1 %d %d 50 0 46 0.0 1 0.0 %d %d %d %d %d %d %d %d\n", color,
               color, x0, y0, s_XFigRealLineWidth / 2, s_XFigRealLineWidth / 2,
               x0, y0, x0 + s_XFigRealLineWidth, y0);
     s_XFigStream << s;
@@ -477,71 +477,71 @@ static void xfig_print_point(double _x0, double _y0, int color)
 
 static void xfig_print_saddle(double x, double y)
 {
-    xfig_print_box((int)x, (int)y, g_printColorTable[CSADDLE]);
+    xfig_print_box((int)x, (int)y, printColorTable(CSADDLE));
 }
 
 static void xfig_print_stablenode(double x, double y)
 {
-    xfig_print_box((int)x, (int)y, g_printColorTable[CNODE_S]);
+    xfig_print_box((int)x, (int)y, printColorTable(CNODE_S));
 }
 static void xfig_print_unstablenode(double x, double y)
 {
-    xfig_print_box((int)x, (int)y, g_printColorTable[CNODE_U]);
+    xfig_print_box((int)x, (int)y, printColorTable(CNODE_U));
 }
 
 static void xfig_print_stableweakfocus(double x, double y)
 {
-    xfig_print_diamond((int)x, (int)y, g_printColorTable[CWEAK_FOCUS_S]);
+    xfig_print_diamond((int)x, (int)y, printColorTable(CWEAK_FOCUS_S));
 }
 
 static void xfig_print_unstableweakfocus(double x, double y)
 {
-    xfig_print_diamond((int)x, (int)y, g_printColorTable[CWEAK_FOCUS_U]);
+    xfig_print_diamond((int)x, (int)y, printColorTable(CWEAK_FOCUS_U));
 }
 
 static void xfig_print_weakfocus(double x, double y)
 {
-    xfig_print_diamond((int)x, (int)y, g_printColorTable[CWEAK_FOCUS]);
+    xfig_print_diamond((int)x, (int)y, printColorTable(CWEAK_FOCUS));
 }
 
 static void xfig_print_center(double x, double y)
 {
-    xfig_print_diamond((int)x, (int)y, g_printColorTable[CCENTER]);
+    xfig_print_diamond((int)x, (int)y, printColorTable(CCENTER));
 }
 
 static void xfig_print_stablestrongfocus(double x, double y)
 {
-    xfig_print_diamond((int)x, (int)y, g_printColorTable[CSTRONG_FOCUS_S]);
+    xfig_print_diamond((int)x, (int)y, printColorTable(CSTRONG_FOCUS_S));
 }
 
 static void xfig_print_unstablestrongfocus(double x, double y)
 {
-    xfig_print_diamond((int)x, (int)y, g_printColorTable[CSTRONG_FOCUS_U]);
+    xfig_print_diamond((int)x, (int)y, printColorTable(CSTRONG_FOCUS_U));
 }
 
 static void xfig_print_sesaddle(double x, double y)
 {
-    xfig_print_triangle((int)x, (int)y, g_printColorTable[CSADDLE]);
+    xfig_print_triangle((int)x, (int)y, printColorTable(CSADDLE));
 }
 
 static void xfig_print_sesaddlenode(double x, double y)
 {
-    xfig_print_triangle((int)x, (int)y, g_printColorTable[CSADDLE_NODE]);
+    xfig_print_triangle((int)x, (int)y, printColorTable(CSADDLE_NODE));
 }
 
 static void xfig_print_sestablenode(double x, double y)
 {
-    xfig_print_triangle((int)x, (int)y, g_printColorTable[CNODE_S]);
+    xfig_print_triangle((int)x, (int)y, printColorTable(CNODE_S));
 }
 
 static void xfig_print_seunstablenode(double x, double y)
 {
-    xfig_print_triangle((int)x, (int)y, g_printColorTable[CNODE_U]);
+    xfig_print_triangle((int)x, (int)y, printColorTable(CNODE_U));
 }
 
 static void xfig_print_degen(double x, double y)
 {
-    xfig_print_cross((int)x, (int)y, g_printColorTable[CDEGEN]);
+    xfig_print_cross((int)x, (int)y, printColorTable(CDEGEN));
 }
 
 // ---------------------------------------------------------------------------------------
@@ -636,7 +636,31 @@ void prepareXFigPrinting(int w, int h, bool iszoom, bool isblackwhite,
                "Inches\n"   // use inches (XFIG makes rounding errors with
                             // centimeters)
                "1200 2\n";  // unused in XFIG???
-
+        if (!bgColours::PRINT_WHITE_BG) {
+            /*
+                object type     2   (=polyline)
+                subtype         2   (=box)
+                linestyle       0   (=solid)
+                thickness       1   (in 1/80 of an inch)
+                pencolor        0   (=black)
+                fillcolor       7   (=white)
+                depth           999 (below other objects)
+                penstyle        -1  (unused in XFIG 3.1)
+                areafill        0   (pencolor fill)
+                styleval        0.0 (only relevant for dashed lines)
+                joinstyle       0   (=miter)
+                capstyle        0   (=butt)
+                radius          0   (no rounded box)
+                forwardarrow    0   (no arrow)
+                backwardarrow   0   (no arrow)
+                npoints         5   (=5 points)
+            */
+            QString s;
+            s.sprintf("2 2 0 1 0 7 999 -1 0 0.0000000 0 0 0 0 0 5\n"
+                      "    %d %d %d %d %d %d %d %d %d %d\n",
+                      0, 0, s_XFigW, 0, s_XFigW, s_XFigH, 0, s_XFigH, 0, 0);
+            s_XFigStream << s;
+        }
         if (g_VFResults.typeofview_ == TYPEOFVIEW_PLANE || iszoom) {
             /*
                 object type     2   (=polyline)
@@ -645,7 +669,7 @@ void prepareXFigPrinting(int w, int h, bool iszoom, bool isblackwhite,
                 thickness       1   (in 1/80 of an inch)
                 pencolor        0   (=black)
                 fillcolor       7   (=white)
-                depth           0   (no precedence over other objects)
+                depth           998 (below all objects except background)
                 penstyle        0   (unused in XFIG 3.1)
                 areafill        -1  (no fill)
                 styleval        0.0 (only relevant for dashed lines)
@@ -657,7 +681,7 @@ void prepareXFigPrinting(int w, int h, bool iszoom, bool isblackwhite,
                 npoints         5   (=5 points)
             */
             QString s;
-            s.sprintf("2 2 0 1 0 7 0 0 -1 0.0000000 0 0 0 0 0 5\n"
+            s.sprintf("2 2 0 1 0 7 998 0 -1 0.0000000 0 0 0 0 0 5\n"
                       "    %d %d %d %d %d %d %d %d %d %d\n",
                       0, 0, s_XFigW, 0, s_XFigW, s_XFigH, 0, s_XFigH, 0, 0);
             s_XFigStream << s;

--- a/src-gui/p4/win_find.cpp
+++ b/src-gui/p4/win_find.cpp
@@ -350,6 +350,10 @@ QFindDlg::QFindDlg(QStartDlg *startdlg) : QWidget(startdlg)
     // readSettings();
 }
 
+void QFindDlg::onSaveSignal() {
+    //QSettings settings(g_ThisVF->getbarefilename().append(".conf"), QSettings::NativeFormat);
+    //settings.setValue("QFindDlg/state",saveState());
+}
 
 void QFindDlg::onBtnLoad()
 {

--- a/src-gui/p4/win_find.cpp
+++ b/src-gui/p4/win_find.cpp
@@ -314,7 +314,8 @@ QFindDlg::QFindDlg(QStartDlg *startdlg) : QWidget(startdlg)
     connect(btn_load_, &QPushButton::clicked, this, &QFindDlg::onBtnLoad);
     connect(btn_save_, &QPushButton::clicked, this, &QFindDlg::onBtnSave);
     connect(btn_eval_, &QPushButton::clicked, this, &QFindDlg::onBtnEval);
-    // QObject::connect(g_ThisVF, SIGNAL(onSave()), this, SLOT(onSaveState()));
+    connect(g_ThisVF, &QInputVF::saveSignal, this, &QFindDlg::onSaveSignal);
+    // TODO: implement onSaveSignal slot
 
     // finishing
 
@@ -391,7 +392,6 @@ void QFindDlg::onBtnSave()
             this, "P4", "Unable to save the input vector field.\n"
                         "Please check permissions on the write location.\n");
     }
-    // emit saveStateSignal();
 }
 
 void QFindDlg::onBtnEval()

--- a/src-gui/p4/win_find.h
+++ b/src-gui/p4/win_find.h
@@ -66,9 +66,6 @@ class QFindDlg : public QWidget
     //void saveSettings();
     //void readSettings();
 
-  signals:
-    void saveStateSignal();
-
   public slots:
     // void btn_maple_toggled(bool);
     // void btn_reduce_toggled(bool);
@@ -80,6 +77,8 @@ class QFindDlg : public QWidget
     void onBtnLoad();
     void onBtnSave();
     void onBtnEval();
+
+    void onSaveSignal();
 };
 
 #endif /* WIN_FIND_H */

--- a/src-gui/p4/win_legend.cpp
+++ b/src-gui/p4/win_legend.cpp
@@ -23,10 +23,8 @@
 #include "main.h"
 #include "p4application.h"
 #include "plot_points.h"
-#include "file_vf.h"
 
 #include <QPainter>
-#include <QSettings>
 
 // -----------------------------------------------------------------------
 //                          Define Colors in RGB
@@ -87,20 +85,6 @@ QLegendWnd::QLegendWnd() : QWidget(nullptr, Qt::Tool | Qt::WindowStaysOnTopHint)
     setMinimumSize(w, h);
     setMaximumSize(w, h);
     setP4WindowTitle(this, "P4 Legend");
-
-    connect(g_ThisVF,&QInputVF::saveSignal,this,&QLegendWnd::onSaveSignal);
-}
-
-void QLegendWnd::onSaveSignal() {
-    QSettings settings(g_ThisVF->getbarefilename().append(".conf"), QSettings::NativeFormat);
-    settings.setValue("QLegendWnd/size",size());
-    settings.setValue("QLegendWnd/pos",pos());
-}
-
-void QLegendWnd::loadState() {
-    QSettings settings(g_ThisVF->getbarefilename().append(".conf"), QSettings::NativeFormat);
-    resize(settings.value("QLegendWnd/size").toSize());
-    move(settings.value("QLegendWnd/pos").toPoint());
 }
 
 void QLegendWnd::paintEvent(QPaintEvent *p)

--- a/src-gui/p4/win_legend.cpp
+++ b/src-gui/p4/win_legend.cpp
@@ -94,7 +94,7 @@ void QLegendWnd::paintEvent(QPaintEvent *p)
 
     paint.setFont(*(g_p4app->legendFont_));
 
-    paint.setPen(QPen(QXFIGCOLOR(CFOREGROUND)));
+    paint.setPen(QPen(QXFIGCOLOR(bgColours::CFOREGROUND)));
     paint.drawText(hmargin1_, vmargin1_, "Non-Degenerate:");
     paint.drawText(hmargin4_, vmargin1_, "Semi-hyperbolic:");
     paint.drawText(hmargin1_, vmargin3_, "Separatrices:");
@@ -187,7 +187,7 @@ void QLegendWnd::paintEvent(QPaintEvent *p)
                    hmargin1_ + sepwidth_ - 1,
                    vmargin4_ + 3 * interline_ - xheight_);
 
-    paint.setPen(QPen(QXFIGCOLOR(CORBIT)));
+    paint.setPen(QPen(QXFIGCOLOR(bgColours::CORBIT)));
     paint.drawLine(hmargin4_, vmargin25_ + interline_ - xheight_,
                    hmargin4_ + orbitwidth_ - 1,
                    vmargin25_ + interline_ - xheight_);
@@ -248,7 +248,7 @@ void QLegendWnd::calculateGeometry(void)
     QFontMetrics fm(*(g_p4app->legendFont_));
 
     QPalette palette;
-    palette.setColor(backgroundRole(), QXFIGCOLOR(CBACKGROUND));
+    palette.setColor(backgroundRole(), QXFIGCOLOR(bgColours::CBACKGROUND));
     setPalette(palette);
 
     hmargin1_ = fm.maxWidth();

--- a/src-gui/p4/win_legend.cpp
+++ b/src-gui/p4/win_legend.cpp
@@ -23,8 +23,10 @@
 #include "main.h"
 #include "p4application.h"
 #include "plot_points.h"
+#include "file_vf.h"
 
 #include <QPainter>
+#include <QSettings>
 
 // -----------------------------------------------------------------------
 //                          Define Colors in RGB
@@ -85,6 +87,20 @@ QLegendWnd::QLegendWnd() : QWidget(nullptr, Qt::Tool | Qt::WindowStaysOnTopHint)
     setMinimumSize(w, h);
     setMaximumSize(w, h);
     setP4WindowTitle(this, "P4 Legend");
+
+    connect(g_ThisVF,&QInputVF::saveSignal,this,&QLegendWnd::onSaveSignal);
+}
+
+void QLegendWnd::onSaveSignal() {
+    QSettings settings(g_ThisVF->getbarefilename().append(".conf"), QSettings::NativeFormat);
+    settings.setValue("QLegendWnd/size",size());
+    settings.setValue("QLegendWnd/pos",pos());
+}
+
+void QLegendWnd::loadState() {
+    QSettings settings(g_ThisVF->getbarefilename().append(".conf"), QSettings::NativeFormat);
+    resize(settings.value("QLegendWnd/size").toSize());
+    move(settings.value("QLegendWnd/pos").toPoint());
 }
 
 void QLegendWnd::paintEvent(QPaintEvent *p)

--- a/src-gui/p4/win_legend.h
+++ b/src-gui/p4/win_legend.h
@@ -34,9 +34,6 @@ class QLegendWnd : public QWidget
     void calculateGeometry();
     void loadState();
 
-  public slots:
-    void onSaveSignal();
-    
   private:
     QBoxLayout *mainLayout_;
 

--- a/src-gui/p4/win_legend.h
+++ b/src-gui/p4/win_legend.h
@@ -31,8 +31,12 @@ class QLegendWnd : public QWidget
   public:
     QLegendWnd();
     void paintEvent(QPaintEvent *);
-    void calculateGeometry(void);
+    void calculateGeometry();
+    void loadState();
 
+  public slots:
+    void onSaveSignal();
+    
   private:
     QBoxLayout *mainLayout_;
 

--- a/src-gui/p4/win_main.cpp
+++ b/src-gui/p4/win_main.cpp
@@ -33,15 +33,14 @@
 #include <QTextBrowser>
 
 QStartDlg *g_p4stardlg = nullptr;
+// initialise background colors
+int bgColours::CBACKGROUND = BLACK;
+int bgColours::CFOREGROUND = WHITE;
+int bgColours::CORBIT = YELLOW;
 
 QStartDlg::QStartDlg(const QString &autofilename) : QWidget()
 {
     // general initialization
-
-    // initialise background colors
-    bgColours::CBACKGROUND = BLACK;
-    bgColours::CFOREGROUND = WHITE;
-    bgColours::CORBIT = YELLOW;
 
     QString cap;
     cap = "Planar Polynomial Phase Portraits";

--- a/src-gui/p4/win_main.cpp
+++ b/src-gui/p4/win_main.cpp
@@ -124,6 +124,8 @@ QStartDlg::QStartDlg(const QString &autofilename) : QWidget()
     connect(btn_browse_, &QPushButton::clicked, this, &QStartDlg::onBrowse);
     connect(edt_name_, &QLineEdit::textChanged, this,
             &QStartDlg::onFilenameChange);
+    connect(g_ThisVF, &QInputVF::saveSignal, this, &QStartDlg::onSaveSignal);
+    connect(g_ThisVF, &QInputVF::loadSignal, this, &QStartDlg::onLoadSignal);
 
     // setting focus
 
@@ -157,7 +159,28 @@ QStartDlg::QStartDlg(const QString &autofilename) : QWidget()
     setP4WindowTitle(this, cap);
 }
 
-void QStartDlg::onHelp(void)
+void QStartDlg::onSaveSignal() {
+    QSettings settings(g_ThisVF->getbarefilename().append(".conf"),QSettings::NativeFormat);
+    if (plotWindow_!=nullptr)
+        settings.setValue("QStartDlg/plotWindow",true);
+    else
+        settings.setValue("QStartDlg/plotWindow",false);
+
+}
+
+void QStartDlg::onLoadSignal() {
+    QSettings settings(g_ThisVF->getbarefilename().append(".conf"),QSettings::NativeFormat);    
+    if (settings.value("QStartDlg/plotWindow").toBool()) {
+        if (plotWindow_!=nullptr)
+            plotWindow_->show();
+        else {
+            onPlot();
+            plotWindow_->onLoadSignal();
+        }
+    }
+}
+
+void QStartDlg::onHelp()
 {
     // display help
     QTextBrowser *hlp;
@@ -199,7 +222,7 @@ void QStartDlg::onHelp(void)
     helpWindow_ = hlp;
 }
 
-void QStartDlg::onPlot(void)
+void QStartDlg::onPlot()
 {
     // show plot window
 
@@ -238,7 +261,7 @@ void QStartDlg::onPlot(void)
     plotWindow_->adjustHeight();
 }
 
-void QStartDlg::onQuit(void)
+void QStartDlg::onQuit()
 {
     if (plotWindow_ != nullptr) {
         delete plotWindow_;
@@ -274,7 +297,7 @@ void QStartDlg::onFilenameChange(const QString &fname)
     g_ThisVF->filename_ = fname;
 }
 
-void QStartDlg::signalEvaluating(void)
+void QStartDlg::signalEvaluating()
 {
     // disable view button, disable plot button:
 
@@ -293,7 +316,7 @@ void QStartDlg::signalEvaluating(void)
         plotWindow_->signalEvaluating();
 }
 
-void QStartDlg::signalEvaluated(void)
+void QStartDlg::signalEvaluated()
 {
     // enable view button, disable plot button:
 
@@ -383,17 +406,17 @@ void QStartDlg::signalEvaluated(void)
         signalChanged();
 }
 
-void QStartDlg::signalSaved(void)
+void QStartDlg::signalSaved()
 {
     //
 }
 
-void QStartDlg::signalLoaded(void)
+void QStartDlg::signalLoaded()
 {
     //
 }
 
-void QStartDlg::signalChanged(void)
+void QStartDlg::signalChanged()
 {
     if (viewFiniteWindow_ != nullptr) {
         viewFiniteWindow_->setFont(*(g_p4app->courierFont_));
@@ -407,7 +430,7 @@ void QStartDlg::signalChanged(void)
     }
 }
 
-void QStartDlg::onBrowse(void)
+void QStartDlg::onBrowse()
 {
     QString result;
 
@@ -421,7 +444,7 @@ void QStartDlg::onBrowse(void)
     }
 }
 
-void QStartDlg::onAbout(void)
+void QStartDlg::onAbout()
 {
     QP4AboutDlg *pdlg;
     pdlg = new QP4AboutDlg(this, 0);

--- a/src-gui/p4/win_main.cpp
+++ b/src-gui/p4/win_main.cpp
@@ -37,7 +37,7 @@ QStartDlg *g_p4stardlg = nullptr;
 int bgColours::CBACKGROUND = BLACK;
 int bgColours::CFOREGROUND = WHITE;
 int bgColours::CORBIT = YELLOW;
-bool bgColours::PRINT_REVERSE_BLACK_AND_WHITE = true;
+bool bgColours::PRINT_WHITE_BG = true;
 
 QStartDlg::QStartDlg(const QString &autofilename) : QWidget()
 {

--- a/src-gui/p4/win_main.cpp
+++ b/src-gui/p4/win_main.cpp
@@ -38,6 +38,11 @@ QStartDlg::QStartDlg(const QString &autofilename) : QWidget()
 {
     // general initialization
 
+    // initialise background colors
+    bgColours::CBACKGROUND = BLACK;
+    bgColours::CFOREGROUND = WHITE;
+    bgColours::CORBIT = YELLOW;
+
     QString cap;
     cap = "Planar Polynomial Phase Portraits";
     //  setFont( QFont( FONTSTYLE, FONTSIZE ) );

--- a/src-gui/p4/win_main.cpp
+++ b/src-gui/p4/win_main.cpp
@@ -37,6 +37,7 @@ QStartDlg *g_p4stardlg = nullptr;
 int bgColours::CBACKGROUND = BLACK;
 int bgColours::CFOREGROUND = WHITE;
 int bgColours::CORBIT = YELLOW;
+bool bgColours::PRINT_REVERSE_BLACK_AND_WHITE = true;
 
 QStartDlg::QStartDlg(const QString &autofilename) : QWidget()
 {

--- a/src-gui/p4/win_main.h
+++ b/src-gui/p4/win_main.h
@@ -76,9 +76,6 @@ class QStartDlg : public QWidget
 
     void customEvent(QEvent *e);
 
-    void saveSettings();
-    void readSettings();
-
   public slots:
     // following slots are called by QT when a button is pressed or a file name
     // is changed:
@@ -91,6 +88,8 @@ class QStartDlg : public QWidget
     void onAbout();
     void onFilenameChange(const QString &);
     QWidget *showText(QWidget *win, QString caption, QString fname);
+    void onSaveSignal();
+    void onLoadSignal();
 
   private:
     QBoxLayout *mainLayout_;

--- a/src-gui/p4/win_plot.cpp
+++ b/src-gui/p4/win_plot.cpp
@@ -193,16 +193,6 @@ QPlotWnd::~QPlotWnd()
 {
     zoomWindows_.clear();
     numZooms_=0;
-    /*
-    if (numZooms_ != 0) {
-        for (int i = 0; i < numZooms_; i++) {
-            delete zoomWindows_[i];
-            zoomWindows_[i] = nullptr;
-        }
-        delete zoomWindows_;
-        zoomWindows_ = nullptr;
-        numZooms_ = 0;
-    }*/
 
     delete legendWindow_;
     legendWindow_ = nullptr;
@@ -243,7 +233,6 @@ void QPlotWnd::onLoadSignal() {
 
     numZooms_ = settings.value("QPlotWnd/numZooms").toInt();
     if (numZooms_ != 0) {
-        //zoomWindows_ = (QZoomWnd **)realloc(zoomWindows_,sizeof(QZoomWnd *) * (numZooms_ + 1));
         for (int i = 1; i <= numZooms_; i++) {
             QString zoomName = QString("QZoomWnd").append(i);
             settings.beginGroup(zoomName);

--- a/src-gui/p4/win_plot.cpp
+++ b/src-gui/p4/win_plot.cpp
@@ -36,8 +36,8 @@
 #include "win_zoom.h"
 
 #include <QPrintDialog>
-#include <QToolBar>
 #include <QSettings>
+#include <QToolBar>
 
 QPlotWnd::QPlotWnd(QStartDlg *main) : QMainWindow()
 {
@@ -53,16 +53,15 @@ QPlotWnd::QPlotWnd(QStartDlg *main) : QMainWindow()
 
     numZooms_ = 0;
     lastZoomIdentifier_ = 0;
-    //zoomWindows_ = nullptr;
 
     //    QPalette palette;
     //    palette.setColor(backgroundRole(), QXFIGCOLOR(CBACKGROUND) );
     //    setPalette(palette);
 
     toolBar1 = new QToolBar("PlotBar1", this);
-    toolBar1->setSizePolicy(QSizePolicy::Minimum,QSizePolicy::Preferred);
+    toolBar1->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Preferred);
     toolBar2 = new QToolBar("PlotBar2", this);
-    toolBar2->setSizePolicy(QSizePolicy::Minimum,QSizePolicy::Preferred);    
+    toolBar2->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Preferred);
     toolBar1->setMovable(false);
     toolBar2->setMovable(false);
 
@@ -88,7 +87,8 @@ QPlotWnd::QPlotWnd(QStartDlg *main) : QMainWindow()
 
     actIntParams_ = new QAction("&Integration Parameters", this);
     actIntParams_->setShortcut(Qt::ALT + Qt::Key_I);
-    connect(actIntParams_, &QAction::triggered, this, &QPlotWnd::onBtnIntParams);
+    connect(actIntParams_, &QAction::triggered, this,
+            &QPlotWnd::onBtnIntParams);
     toolBar1->addAction(actIntParams_);
 
     actGCF_ = new QAction("&GCF", this);
@@ -119,7 +119,8 @@ QPlotWnd::QPlotWnd(QStartDlg *main) : QMainWindow()
     toolBar2->addAction(actLimitCycles_);
 
     actIsoclines_ = new QAction("Isoclines", this);
-    connect(actIsoclines_, &QAction::triggered, this, &QPlotWnd::onBtnIsoclines);
+    connect(actIsoclines_, &QAction::triggered, this,
+            &QPlotWnd::onBtnIsoclines);
     toolBar2->addAction(actIsoclines_);
 
     actView_ = new QAction("&View", this);
@@ -135,7 +136,6 @@ QPlotWnd::QPlotWnd(QStartDlg *main) : QMainWindow()
     addToolBar(Qt::TopToolBarArea, toolBar1);
     addToolBarBreak(Qt::TopToolBarArea);
     addToolBar(Qt::TopToolBarArea, toolBar2);
-
 
     connect(g_ThisVF, &QInputVF::saveSignal, this, &QPlotWnd::onSaveSignal);
     connect(g_ThisVF, &QInputVF::loadSignal, this, &QPlotWnd::onLoadSignal);
@@ -192,7 +192,7 @@ QPlotWnd::QPlotWnd(QStartDlg *main) : QMainWindow()
 QPlotWnd::~QPlotWnd()
 {
     zoomWindows_.clear();
-    numZooms_=0;
+    numZooms_ = 0;
 
     delete legendWindow_;
     legendWindow_ = nullptr;
@@ -217,17 +217,19 @@ QPlotWnd::~QPlotWnd()
     g_ThisVF->isoclinesDlg_ = nullptr;
 }
 
-void QPlotWnd::onSaveSignal() {
+void QPlotWnd::onSaveSignal()
+{
     QString fname = g_ThisVF->getbarefilename().append(".conf");
     QSettings settings(fname, QSettings::NativeFormat);
-    settings.setValue("QPlotWnd/size",size());
-    settings.setValue("QPlotWnd/pos",pos());
-    settings.setValue("QPlotWnd/numZooms",numZooms_);
+    settings.setValue("QPlotWnd/size", size());
+    settings.setValue("QPlotWnd/pos", pos());
+    settings.setValue("QPlotWnd/numZooms", numZooms_);
 }
 
-void QPlotWnd::onLoadSignal() {
+void QPlotWnd::onLoadSignal()
+{
     QString fname = g_ThisVF->getbarefilename().append(".conf");
-    QSettings settings(fname,QSettings::NativeFormat);
+    QSettings settings(fname, QSettings::NativeFormat);
     resize(settings.value("QPlotWnd/size").toSize());
     move(settings.value("QPlotWnd/pos").toPoint());
 
@@ -241,7 +243,9 @@ void QPlotWnd::onLoadSignal() {
             double currentZoomX2 = settings.value("x2").toDouble();
             double currentZoomY1 = settings.value("y1").toDouble();
             double currentZoomY2 = settings.value("y2").toDouble();
-            QZoomWnd *thiszoom = new QZoomWnd(this, currentZoomId, currentZoomX1,currentZoomY1, currentZoomX2, currentZoomY2);
+            QZoomWnd *thiszoom =
+                new QZoomWnd(this, currentZoomId, currentZoomX1, currentZoomY1,
+                             currentZoomX2, currentZoomY2);
             thiszoom->show();
             thiszoom->raise();
             thiszoom->adjustHeight();
@@ -251,8 +255,6 @@ void QPlotWnd::onLoadSignal() {
             settings.endGroup();
         }
     }
-    
-
 }
 
 void QPlotWnd::adjustHeight(void)
@@ -455,7 +457,8 @@ void QPlotWnd::openZoomWindow(double x1, double y1, double x2, double y2)
     if (x1 == x2 || y1 == y2)
         return;
 
-    QZoomWnd *newZoom = new QZoomWnd(this, ++lastZoomIdentifier_, x1, y1, x2, y2);
+    QZoomWnd *newZoom =
+        new QZoomWnd(this, ++lastZoomIdentifier_, x1, y1, x2, y2);
     newZoom->show();
     newZoom->raise();
     newZoom->adjustHeight();
@@ -473,7 +476,7 @@ void QPlotWnd::closeZoomWindow(int id)
             return;
         }
     }
-    return; //error, zoom window not found
+    return; // error, zoom window not found
 }
 
 void QPlotWnd::customEvent(QEvent *_e)
@@ -520,7 +523,7 @@ void QPlotWnd::customEvent(QEvent *_e)
         p = (struct DOUBLEPOINT *)(e->data());
         x = p->x;
         y = p->y;
-        //void *win = *((void **)(p + 1));
+        // void *win = *((void **)(p + 1));
         delete p;
         p = nullptr;
 

--- a/src-gui/p4/win_plot.cpp
+++ b/src-gui/p4/win_plot.cpp
@@ -53,6 +53,7 @@ QPlotWnd::QPlotWnd(QStartDlg *main) : QMainWindow()
 
     numZooms_ = 0;
     lastZoomIdentifier_ = 0;
+    flagAllSepsPlotted_ = false;
 
     //    QPalette palette;
     //    palette.setColor(backgroundRole(), QXFIGCOLOR(CBACKGROUND) );
@@ -224,6 +225,7 @@ void QPlotWnd::onSaveSignal()
     settings.setValue("QPlotWnd/size", size());
     settings.setValue("QPlotWnd/pos", pos());
     settings.setValue("QPlotWnd/numZooms", numZooms_);
+    settings.setValue("QPlotWnd/allSeps",flagAllSepsPlotted_);
 }
 
 void QPlotWnd::onLoadSignal()
@@ -254,6 +256,10 @@ void QPlotWnd::onLoadSignal()
             zoomWindows_.push_back(boost::shared_ptr<QZoomWnd>(thiszoom));
             settings.endGroup();
         }
+    }
+
+    if (settings.value("QPlotWnd/allSeps").toBool()) {
+        onBtnPlotAllSeps(); 
     }
 }
 
@@ -373,6 +379,7 @@ void QPlotWnd::onBtnPlotAllSeps(void)
     sphere_->prepareDrawing();
     plot_all_sep(sphere_);
     sphere_->finishDrawing();
+    flagAllSepsPlotted_ = true;
 }
 
 void QPlotWnd::onBtnLimitCycles(void)

--- a/src-gui/p4/win_plot.cpp
+++ b/src-gui/p4/win_plot.cpp
@@ -230,12 +230,6 @@ void QPlotWnd::onSaveSignal() {
     settings.setValue("QPlotWnd/size",size());
     settings.setValue("QPlotWnd/pos",pos());
     settings.setValue("QPlotWnd/numZooms",numZooms_);
-    if (numZooms_ != 0) {
-        for (int i = 0; i < numZooms_; i++) {
-            QString valuename = QString("QPlotDlg/zoomid").append(i);
-            settings.setValue(valuename,true);
-        }
-    }
 }
 
 void QPlotWnd::onLoadSignal() {
@@ -243,10 +237,24 @@ void QPlotWnd::onLoadSignal() {
     QSettings settings(fname,QSettings::NativeFormat);
     resize(settings.value("QPlotWnd/size").toSize());
     move(settings.value("QPlotWnd/pos").toPoint());
-    int numZooms = settings.value("QPlotWnd/numZooms").toInt();
-    if (numZooms != 0) {
-        for (int i = 0; i < numZooms; i++) {
-            //TODO: crear zoom windows i cridar el load després d'haverles creat
+
+    numZooms_ = settings.value("QPlotWnd/numZooms").toInt();
+    if (numZooms_ != 0) {
+        zoomWindows_ = (QZoomWnd **)realloc(zoomWindows_,sizeof(QZoomWnd *) * (numZooms_ + 1));
+        for (int i = 0; i < numZooms_; i++) {
+            settings.beginGroup(QString("QZoomWnd").append(i));
+            int currentZoomId = settings.value("id").toInt();
+            double currentZoomX1 = settings.value("x1").toDouble();
+            double currentZoomX2 = settings.value("x2").toDouble();
+            double currentZoomY1 = settings.value("y1").toDouble();
+            double currentZoomY2 = settings.value("y2").toDouble();
+            zoomWindows_[i] = new QZoomWnd(this, currentZoomId, currentZoomX1,currentZoomY1, currentZoomX2, currentZoomY2);
+            zoomWindows_[i]->show();
+            zoomWindows_[i]->raise();
+            zoomWindows_[i]->adjustHeight();
+            zoomWindows_[i]->resize(settings.value("size").toSize());
+            zoomWindows_[i]->move(settings.value("pos").toPoint());
+            settings.endGroup();
         }
     }
     

--- a/src-gui/p4/win_plot.cpp
+++ b/src-gui/p4/win_plot.cpp
@@ -56,7 +56,7 @@ QPlotWnd::QPlotWnd(QStartDlg *main) : QMainWindow()
     flagAllSepsPlotted_ = false;
 
     //    QPalette palette;
-    //    palette.setColor(backgroundRole(), QXFIGCOLOR(CBACKGROUND) );
+    //    palette.setColor(backgroundRole(), QXFIGCOLOR(bgColours::CBACKGROUND) );
     //    setPalette(palette);
 
     toolBar1 = new QToolBar("PlotBar1", this);

--- a/src-gui/p4/win_plot.cpp
+++ b/src-gui/p4/win_plot.cpp
@@ -227,25 +227,29 @@ QPlotWnd::~QPlotWnd()
 void QPlotWnd::onSaveSignal() {
     QString fname = g_ThisVF->getbarefilename().append(".conf");
     QSettings settings(fname, QSettings::NativeFormat);
-    settings.setValue("QFindDlg/size",size());
-    settings.setValue("QFindDlg/pos",pos());
-    if (legendWindow_!=nullptr)
-        settings.setValue("QFindDlg/legendWindow",true);
-    else
-        settings.setValue("QFindDlg/legendWindow",false);
-        
+    settings.setValue("QPlotWnd/size",size());
+    settings.setValue("QPlotWnd/pos",pos());
+    settings.setValue("QPlotWnd/numZooms",numZooms_);
+    if (numZooms_ != 0) {
+        for (int i = 0; i < numZooms_; i++) {
+            QString valuename = QString("QPlotDlg/zoomid").append(i);
+            settings.setValue(valuename,true);
+        }
+    }
 }
-//TODO: fer que s'obri la finestra de plot al donarli a load i abans de carregar aquesta configuració (a win_main?)
+
 void QPlotWnd::onLoadSignal() {
     QString fname = g_ThisVF->getbarefilename().append(".conf");
     QSettings settings(fname,QSettings::NativeFormat);
-    resize(settings.value("QFindDlg/size").toSize());
-    move(settings.value("QFindDlg/pos").toPoint());
-    
-    if (settings.value("QFindDlg/legendWindow").toBool()) {
-        legendWindow_->show();
-        legendWindow_->loadState();
+    resize(settings.value("QPlotWnd/size").toSize());
+    move(settings.value("QPlotWnd/pos").toPoint());
+    int numZooms = settings.value("QPlotWnd/numZooms").toInt();
+    if (numZooms != 0) {
+        for (int i = 0; i < numZooms; i++) {
+            //TODO: crear zoom windows i cridar el load després d'haverles creat
+        }
     }
+    
 
 }
 

--- a/src-gui/p4/win_plot.cpp
+++ b/src-gui/p4/win_plot.cpp
@@ -37,6 +37,7 @@
 
 #include <QPrintDialog>
 #include <QToolBar>
+#include <QSettings>
 
 QPlotWnd::QPlotWnd(QStartDlg *main) : QMainWindow()
 {
@@ -135,6 +136,10 @@ QPlotWnd::QPlotWnd(QStartDlg *main) : QMainWindow()
     addToolBarBreak(Qt::TopToolBarArea);
     addToolBar(Qt::TopToolBarArea, toolBar2);
 
+
+    connect(g_ThisVF, &QInputVF::saveSignal, this, &QPlotWnd::onSaveSignal);
+    connect(g_ThisVF, &QInputVF::loadSignal, this, &QPlotWnd::onLoadSignal);
+
 #ifdef TOOLTIPS
 
     actClose_->setToolTip(
@@ -217,6 +222,31 @@ QPlotWnd::~QPlotWnd()
     delete isoclinesWindow_;
     isoclinesWindow_ = nullptr;
     g_ThisVF->isoclinesDlg_ = nullptr;
+}
+
+void QPlotWnd::onSaveSignal() {
+    QString fname = g_ThisVF->getbarefilename().append(".conf");
+    QSettings settings(fname, QSettings::NativeFormat);
+    settings.setValue("QFindDlg/size",size());
+    settings.setValue("QFindDlg/pos",pos());
+    if (legendWindow_!=nullptr)
+        settings.setValue("QFindDlg/legendWindow",true);
+    else
+        settings.setValue("QFindDlg/legendWindow",false);
+        
+}
+//TODO: fer que s'obri la finestra de plot al donarli a load i abans de carregar aquesta configuració (a win_main?)
+void QPlotWnd::onLoadSignal() {
+    QString fname = g_ThisVF->getbarefilename().append(".conf");
+    QSettings settings(fname,QSettings::NativeFormat);
+    resize(settings.value("QFindDlg/size").toSize());
+    move(settings.value("QFindDlg/pos").toPoint());
+    
+    if (settings.value("QFindDlg/legendWindow").toBool()) {
+        legendWindow_->show();
+        legendWindow_->loadState();
+    }
+
 }
 
 void QPlotWnd::adjustHeight(void)

--- a/src-gui/p4/win_plot.cpp
+++ b/src-gui/p4/win_plot.cpp
@@ -59,7 +59,9 @@ QPlotWnd::QPlotWnd(QStartDlg *main) : QMainWindow()
     //    setPalette(palette);
 
     toolBar1 = new QToolBar("PlotBar1", this);
+    toolBar1->setSizePolicy(QSizePolicy::Minimum,QSizePolicy::Preferred);
     toolBar2 = new QToolBar("PlotBar2", this);
+    toolBar2->setSizePolicy(QSizePolicy::Minimum,QSizePolicy::Preferred);    
     toolBar1->setMovable(false);
     toolBar2->setMovable(false);
 

--- a/src-gui/p4/win_plot.cpp
+++ b/src-gui/p4/win_plot.cpp
@@ -39,6 +39,8 @@
 #include <QToolBar>
 #include <QSettings>
 
+#include <iostream>
+
 QPlotWnd::QPlotWnd(QStartDlg *main) : QMainWindow()
 {
     QToolBar *toolBar1;
@@ -241,8 +243,10 @@ void QPlotWnd::onLoadSignal() {
     numZooms_ = settings.value("QPlotWnd/numZooms").toInt();
     if (numZooms_ != 0) {
         zoomWindows_ = (QZoomWnd **)realloc(zoomWindows_,sizeof(QZoomWnd *) * (numZooms_ + 1));
-        for (int i = 0; i < numZooms_; i++) {
-            settings.beginGroup(QString("QZoomWnd").append(i));
+        for (int i = 1; i <= numZooms_; i++) {
+            QString zoomName = QString("QZoomWnd").append(i);
+            settings.beginGroup(zoomName);
+            std::cerr << zoomName.toStdString() << std::endl;
             int currentZoomId = settings.value("id").toInt();
             double currentZoomX1 = settings.value("x1").toDouble();
             double currentZoomX2 = settings.value("x2").toDouble();

--- a/src-gui/p4/win_plot.h
+++ b/src-gui/p4/win_plot.h
@@ -31,6 +31,8 @@
 #include <QHideEvent>
 #include <QMainWindow>
 
+#include <boost/shared_ptr.hpp>
+
 /* Forward-declarations to solve cross-include problems */
 class QGcfDlg;         // in win_gcf.h
 class QCurveDlg;       // in win_curve.h
@@ -81,7 +83,7 @@ class QPlotWnd : public QMainWindow
 
     int numZooms_;
     int lastZoomIdentifier_;
-    QZoomWnd **zoomWindows_; // TODO: fer vector
+    std::vector<boost::shared_ptr<QZoomWnd>> zoomWindows_; // TODO: fer vector
 
   public slots:
     void signalEvaluating();

--- a/src-gui/p4/win_plot.h
+++ b/src-gui/p4/win_plot.h
@@ -84,6 +84,8 @@ class QPlotWnd : public QMainWindow
     int numZooms_;
     int lastZoomIdentifier_;
     std::vector<boost::shared_ptr<QZoomWnd>> zoomWindows_;
+
+    bool flagAllSepsPlotted_;
     
   public slots:
     void signalEvaluating();

--- a/src-gui/p4/win_plot.h
+++ b/src-gui/p4/win_plot.h
@@ -83,8 +83,8 @@ class QPlotWnd : public QMainWindow
 
     int numZooms_;
     int lastZoomIdentifier_;
-    std::vector<boost::shared_ptr<QZoomWnd>> zoomWindows_; // TODO: fer vector
-
+    std::vector<boost::shared_ptr<QZoomWnd>> zoomWindows_;
+    
   public slots:
     void signalEvaluating();
     void signalEvaluated();

--- a/src-gui/p4/win_plot.h
+++ b/src-gui/p4/win_plot.h
@@ -84,32 +84,35 @@ class QPlotWnd : public QMainWindow
     QZoomWnd **zoomWindows_; // TODO: fer vector
 
   public slots:
-    void signalEvaluating(void);
-    void signalEvaluated(void);
-    void signalChanged(void);
+    void signalEvaluating();
+    void signalEvaluated();
+    void signalChanged();
 
-    void onBtnClose(void);
-    void onBtnRefresh(void);
-    void onBtnLegend(void);
-    void onBtnOrbits(void);
-    void onBtnIntParams(void);
-    void onBtnView(void);
-    void onBtnGCF(void);
-    void onBtnCurve(void);
-    void onBtnIsoclines(void);
-    void onBtnPlotSep(void);
-    void onBtnPlotAllSeps(void);
-    void onBtnLimitCycles(void);
-    void onBtnPrint(void);
-    bool close(void);
+    void onBtnClose();
+    void onBtnRefresh();
+    void onBtnLegend();
+    void onBtnOrbits();
+    void onBtnIntParams();
+    void onBtnView();
+    void onBtnGCF();
+    void onBtnCurve();
+    void onBtnIsoclines();
+    void onBtnPlotSep();
+    void onBtnPlotAllSeps();
+    void onBtnLimitCycles();
+    void onBtnPrint();
+    bool close();
 
     void openZoomWindow(double, double, double, double);
     void closeZoomWindow(int id);
-    void configure(void);
+    void configure();
     void customEvent(QEvent *e);
     void hideEvent(QHideEvent *h);
-    void getDlgData(void);
-    void adjustHeight(void);
+    void getDlgData();
+    void adjustHeight();
+
+    void onSaveSignal();
+    void onLoadSignal();
 };
 
 #endif /* WIN_PLOT_H */

--- a/src-gui/p4/win_print.cpp
+++ b/src-gui/p4/win_print.cpp
@@ -22,7 +22,7 @@
 #include "custom.h"
 #include "main.h"
 
-#include <QLabel>
+#include <QButtonGroup>
 
 /*
     The Print Window is a modal dialog box!
@@ -62,6 +62,19 @@ QPrintDlg::QPrintDlg(QWidget *parent, Qt::WindowFlags f) : QDialog(parent, f)
     btn_blackwhite_ = new QCheckBox("&Black&&White printing", this);
     btn_blackwhite_->setChecked(sm_LastBlackWhite);
 
+    lbl_bgcolor_ = new QLabel("Print background colour:", this);
+    btn_whitebg_ = new QRadioButton("&White", this);
+    btn_blackbg_ = new QRadioButton("B&lack", this);
+
+    QButtonGroup *bgcolors = new QButtonGroup(this);
+    bgcolors->addButton(btn_whitebg_);
+    bgcolors->addButton(btn_blackbg_);
+
+    if (bgColours::PRINT_WHITE_BG)
+        btn_whitebg_->toggle();
+    else
+        btn_blackbg_->toggle();
+
 #ifdef TOOLTIPS
 #ifdef USE_SYSTEM_PRINTER
     btn_default_->setToolTip("Print through default printing mechanism.\nIn "
@@ -74,11 +87,18 @@ QPrintDlg::QPrintDlg(QWidget *parent, Qt::WindowFlags f) : QDialog(parent, f)
     btn_jpeg_->setToolTip("Produce a .JPG image file");
     btn_cancel_->setToolTip("Cancel printing");
     btn_blackwhite_->setToolTip(
-        "If checked, produce a black&white image, rather than a color image");
+        "If checked, produce a black&white image, rather than a colour image");
+    lbl_bgcolor_->setToolTip(
+        "Select the background colour to use for printing, "
+        "regardless of plot background colour configuration in "
+        "main settings");
+    btn_whitebg_->setToolTip("Use white background for printing");
+    btn_blackbg_->setToolTip("Use black background for printing");
     edt_resolution_->setToolTip(
         "Choose a resolution. Images of 15cm wide are produced."
         "The number of horizontal pixels is hence 15*resolution/2.54.\n"
-        "This number affects the quality, but not the phsyical dimensions of "
+        "This number affects the quality, but not the phsyical "
+        "dimensions of "
         "picture.");
     edt_linewidth_->setToolTip(
         "The width of lines (orbits, separatrices, ...) in millimeters");
@@ -111,9 +131,22 @@ QPrintDlg::QPrintDlg(QWidget *parent, Qt::WindowFlags f) : QDialog(parent, f)
     connect(btn_jpeg_, &QPushButton::clicked, this,
             &QPrintDlg::onJpegImagePrinter);
     connect(btn_cancel_, &QPushButton::clicked, this, &QPrintDlg::onCancel);
+    connect(btn_whitebg_, &QRadioButton::toggled, this,
+            [=]() { bgColours::PRINT_WHITE_BG = true; });
+    connect(btn_blackbg_, &QRadioButton::toggled, this,
+            [=]() { bgColours::PRINT_WHITE_BG = false; });
 
     mainLayout_->addSpacing(2);
     mainLayout_->addWidget(btn_blackwhite_);
+    mainLayout_->addSpacing(2);
+
+    QHBoxLayout *printColourLayout = new QHBoxLayout();
+    printColourLayout->addWidget(lbl_bgcolor_);
+    printColourLayout->addStretch(0);
+    printColourLayout->addWidget(btn_whitebg_);
+    printColourLayout->addWidget(btn_blackbg_);
+
+    mainLayout_->addLayout(printColourLayout);
     mainLayout_->addSpacing(2);
 
     QHBoxLayout *l1 = new QHBoxLayout();
@@ -155,6 +188,7 @@ bool QPrintDlg::readDialog(void)
     bool result;
 
     sm_LastBlackWhite = btn_blackwhite_->isChecked();
+
     result =
         readFloatField(edt_resolution_, &res, DEFAULT_RESOLUTION, 72, 4800);
     sm_LastResolution = (int)res;

--- a/src-gui/p4/win_print.h
+++ b/src-gui/p4/win_print.h
@@ -23,8 +23,10 @@
 #include <QBoxLayout>
 #include <QCheckBox>
 #include <QDialog>
+#include <QLabel>
 #include <QLineEdit>
 #include <QPushButton>
+#include <QRadioButton>
 #include <QWidget>
 
 class QPrintDlg : public QDialog
@@ -39,6 +41,11 @@ class QPrintDlg : public QDialog
     QPushButton *btn_jpeg_;
     QBoxLayout *mainLayout_;
     QCheckBox *btn_blackwhite_;
+
+    QLabel *lbl_bgcolor_;
+    QRadioButton *btn_whitebg_;
+    QRadioButton *btn_blackbg_;
+
     QLineEdit *edt_resolution_;
     QLineEdit *edt_linewidth_;
     QLineEdit *edt_symbolsize_;

--- a/src-gui/p4/win_settings.cpp
+++ b/src-gui/p4/win_settings.cpp
@@ -24,6 +24,7 @@
 #include "main.h"
 #include "p4settings.h"
 
+#include <QButtonGroup>
 #include <QFileDialog>
 #include <QMessageBox>
 
@@ -108,6 +109,14 @@ QSettingsDlg::QSettingsDlg(QWidget *parent, Qt::WindowFlags f)
     // btn_red->setEnabled(false);
     // lbl_red->setBuddy(edt_red);
 
+    lbl_bgcolor_ = new QLabel("Plot background color", this);
+    btn_bgblack_ = new QRadioButton("Black", this);
+    btn_bgwhite_ = new QRadioButton("White", this);
+
+    QButtonGroup *bgcolors = new QButtonGroup(this);
+    bgcolors->addButton(btn_bgblack_);
+    bgcolors->addButton(btn_bgwhite_);
+
     btn_ok_ = new QPushButton("&Ok", this);
     btn_reset_ = new QPushButton("&Reset", this);
     btn_cancel_ = new QPushButton("&Cancel", this);
@@ -179,7 +188,16 @@ QSettingsDlg::QSettingsDlg(QWidget *parent, Qt::WindowFlags f)
     // lay00->addWidget(edt_red, 4, 1);
     // lay00->addWidget(btn_red, 4, 2);
 
+    QHBoxLayout *bgbuttons = new QHBoxLayout();
+    bgbuttons->addStretch(0);
+    bgbuttons->addWidget(lbl_bgcolor_);
+    bgbuttons->addWidget(btn_bgblack_);
+    bgbuttons->addWidget(btn_bgwhite_);
+    bgbuttons->addStretch(0);
+
     mainLayout_->addLayout(lay00);
+    mainLayout_->addSpacing(3);
+    mainLayout_->addLayout(bgbuttons);
     mainLayout_->addSpacing(3);
     // mainLayout_->addSpacing(4);
     mainLayout_->addLayout(buttons);
@@ -198,6 +216,17 @@ QSettingsDlg::QSettingsDlg(QWidget *parent, Qt::WindowFlags f)
     connect(btn_ok_, &QPushButton::clicked, this, &QSettingsDlg::onOk);
     connect(btn_reset_, &QPushButton::clicked, this, &QSettingsDlg::onReset);
     connect(btn_cancel_, &QPushButton::clicked, this, &QSettingsDlg::onCancel);
+
+    connect(btn_bgblack_, &QRadioButton::toggled, this, [=]() {
+        bgColours::CFOREGROUND = WHITE;
+        bgColours::CBACKGROUND = BLACK;
+        bgColours::CORBIT = YELLOW;
+    });
+    connect(btn_bgwhite_, &QRadioButton::toggled, this, [=]() {
+        bgColours::CFOREGROUND = BLACK;
+        bgColours::CBACKGROUND = WHITE;
+        bgColours::CORBIT = GREEN1;
+    });
 
     //#ifdef Q_OS_WIN
     //    edt_red->setEnabled(false);

--- a/src-gui/p4/win_settings.cpp
+++ b/src-gui/p4/win_settings.cpp
@@ -189,11 +189,15 @@ QSettingsDlg::QSettingsDlg(QWidget *parent, Qt::WindowFlags f)
     // lay00->addWidget(btn_red, 4, 2);
 
     QHBoxLayout *bgbuttons = new QHBoxLayout();
-    bgbuttons->addStretch(0);
     bgbuttons->addWidget(lbl_bgcolor_);
+    bgbuttons->addStretch(0);
     bgbuttons->addWidget(btn_bgblack_);
     bgbuttons->addWidget(btn_bgwhite_);
-    bgbuttons->addStretch(0);
+
+    if (bgColours::CBACKGROUND == BLACK)
+        btn_bgblack_->toggle();
+    else
+        btn_bgwhite_->toggle();
 
     mainLayout_->addLayout(lay00);
     mainLayout_->addSpacing(3);

--- a/src-gui/p4/win_settings.h
+++ b/src-gui/p4/win_settings.h
@@ -27,30 +27,42 @@
 #include <QPushButton>
 #include <QString>
 #include <QWidget>
+#include <QRadioButton>
 
 class QSettingsDlg : public QDialog
 {
     Q_OBJECT
 
   private:
+    QLabel *lbl_base_;
+    QLineEdit *edt_base_;
     QPushButton *btn_base_;
+
+    QLabel *lbl_sum_;
+    QLineEdit *edt_sum_;
     QPushButton *btn_sum_;
+
+    QLabel *lbl_temp_;
+    QLineEdit *edt_temp_;
     QPushButton *btn_temp_;
+
+    QLabel *lbl_maple_;
+    QLineEdit *edt_maple_;
     QPushButton *btn_maple_;
+    
+    // QLabel *lbl_red;
+    // QLineEdit *edt_red;
     // QPushButton *btn_red;
+
+    QLabel *lbl_bgcolor_;
+    QRadioButton *btn_bgblack_;
+    QRadioButton *btn_bgwhite_;
+
     QPushButton *btn_ok_;
     QPushButton *btn_reset_;
     QPushButton *btn_cancel_;
-    QLineEdit *edt_base_;
-    QLineEdit *edt_sum_;
-    QLineEdit *edt_temp_;
-    QLineEdit *edt_maple_;
-    // QLineEdit *edt_red;
-    QLabel *lbl_base_;
-    QLabel *lbl_sum_;
-    QLabel *lbl_temp_;
-    QLabel *lbl_maple_;
-    // QLabel *lbl_red;
+    
+    
     QBoxLayout *mainLayout_;
 
   public:

--- a/src-gui/p4/win_sphere.cpp
+++ b/src-gui/p4/win_sphere.cpp
@@ -2202,7 +2202,7 @@ void QWinSphere::printPoincareSphere(void)
     while (p != nullptr) {
         q = p;
         p = p->next;
-        delete q; // free( q );
+        delete q;
         q = nullptr;
     }
 }
@@ -2230,7 +2230,7 @@ void QWinSphere::printPoincareLyapunovSphere(void)
     while (p != nullptr) {
         q = p;
         p = p->next;
-        delete q; // free( q );
+        delete q;
         q = nullptr;
     }
 
@@ -2252,7 +2252,7 @@ void QWinSphere::printPoincareLyapunovSphere(void)
     while (p != nullptr) {
         q = p;
         p = p->next;
-        delete q; // free( q );
+        delete q;
         q = nullptr;
     }
 }
@@ -2522,7 +2522,7 @@ void QWinSphere::preparePrinting(int printmethod, bool isblackwhite,
 
         staticPainter_->translate(tx, ty);
         if (iszoom_ || g_VFResults.typeofview_ == TYPEOFVIEW_PLANE) {
-            QPen p = QPen(QXFIGCOLOR(g_printColorTable[bgColours::CFOREGROUND]), (int)lw);
+            QPen p = QPen(QXFIGCOLOR(printColorTable(bgColours::CFOREGROUND)), (int)lw);
             staticPainter_->setPen(p);
             staticPainter_->drawRect(0, 0, w_, h_);
         }

--- a/src-gui/p4/win_sphere.cpp
+++ b/src-gui/p4/win_sphere.cpp
@@ -279,13 +279,13 @@ void QWinSphere::setupPlot(void)
     while (circleAtInfinity_ != nullptr) {
         t = circleAtInfinity_;
         circleAtInfinity_ = t->next;
-        delete t; // free( t );
+        delete t;
         t = nullptr;
     }
     while (plCircle_ != nullptr) {
         t = plCircle_;
         plCircle_ = t->next;
-        delete t; // free( t );
+        delete t;
         t = nullptr;
     }
 
@@ -364,13 +364,13 @@ QWinSphere::~QWinSphere()
     while (circleAtInfinity_ != nullptr) {
         t = circleAtInfinity_;
         circleAtInfinity_ = t->next;
-        delete t; // free( t );
+        delete t;
         t = nullptr;
     }
     while (plCircle_ != nullptr) {
         t = plCircle_;
         plCircle_ = t->next;
-        delete t; // free( t );
+        delete t;
         t = nullptr;
     }
 
@@ -593,13 +593,13 @@ void QWinSphere::adjustToNewSize(void)
     while (circleAtInfinity_ != nullptr) {
         t = circleAtInfinity_;
         circleAtInfinity_ = t->next;
-        delete t; // free( t );
+        delete t;
         t = nullptr;
     }
     while (plCircle_ != nullptr) {
         t = plCircle_;
         plCircle_ = t->next;
-        delete t; // free( t );
+        delete t;
         t = nullptr;
     }
     if (g_VFResults.typeofview_ == TYPEOFVIEW_SPHERE) {

--- a/src-gui/p4/win_sphere.cpp
+++ b/src-gui/p4/win_sphere.cpp
@@ -272,7 +272,7 @@ void QWinSphere::setupPlot(void)
     struct P4POLYLINES *t;
     QPalette palette;
 
-    spherebgcolor_ = CBACKGROUND;
+    spherebgcolor_ = bgColours::CBACKGROUND;
     palette.setColor(backgroundRole(), QXFIGCOLOR(spherebgcolor_));
     setPalette(palette);
 
@@ -618,7 +618,7 @@ void QWinSphere::adjustToNewSize(void)
 
         QPainter paint(painterCache_);
         paint.fillRect(0, 0, width(), height(),
-                       QColor(QXFIGCOLOR(CBACKGROUND)));
+                       QColor(QXFIGCOLOR(bgColours::CBACKGROUND)));
 
         if (g_VFResults.singinf_)
             paint.setPen(QXFIGCOLOR(CSING));
@@ -696,7 +696,7 @@ void QWinSphere::paintEvent(QPaintEvent *p)
 
         QPainter paint(painterCache_);
         paint.fillRect(0, 0, width(), height(),
-                       QColor(QXFIGCOLOR(CBACKGROUND)));
+                       QColor(QXFIGCOLOR(bgColours::CBACKGROUND)));
 
         if (g_VFResults.singinf_)
             paint.setPen(QXFIGCOLOR(CSING));
@@ -2522,7 +2522,7 @@ void QWinSphere::preparePrinting(int printmethod, bool isblackwhite,
 
         staticPainter_->translate(tx, ty);
         if (iszoom_ || g_VFResults.typeofview_ == TYPEOFVIEW_PLANE) {
-            QPen p = QPen(QXFIGCOLOR(g_printColorTable[CFOREGROUND]), (int)lw);
+            QPen p = QPen(QXFIGCOLOR(g_printColorTable[bgColours::CFOREGROUND]), (int)lw);
             staticPainter_->setPen(p);
             staticPainter_->drawRect(0, 0, w_, h_);
         }
@@ -2681,7 +2681,7 @@ void QWinSphere::signalEvaluating(void)
     /*
         QPalette palette;
         palette.setColor(backgroundRole(), QXFIGCOLOR(spherebgcolor_ =
-       CBACKGROUND) );
+       bgColours::CBACKGROUND) );
         setPalette(palette);
     */
 }

--- a/src-gui/p4/win_zoom.cpp
+++ b/src-gui/p4/win_zoom.cpp
@@ -25,10 +25,12 @@
 #include "plot_tools.h"
 #include "win_event.h"
 #include "win_print.h"
+#include "file_vf.h"
 
 #include <QDesktopWidget>
 #include <QPrintDialog>
 #include <QToolBar>
+#include <QSettings>
 
 QZoomWnd::QZoomWnd(QPlotWnd *main, int id, double x1, double y1, double x2,
                    double y2)
@@ -37,6 +39,10 @@ QZoomWnd::QZoomWnd(QPlotWnd *main, int id, double x1, double y1, double x2,
     QToolBar *toolBar1;
     parent_ = main;
     zoomid_ = id;
+    x1_ = x1;
+    x2_ = x2;
+    y1_ = y1;
+    y2_ = y2;
 
     //    QPalette palette;
     //    palette.setColor(backgroundRole(), QXFIGCOLOR(CBACKGROUND) );
@@ -63,6 +69,9 @@ QZoomWnd::QZoomWnd(QPlotWnd *main, int id, double x1, double y1, double x2,
     connect(actPrint_, &QAction::triggered, this, &QZoomWnd::onBtnPrint);
     toolBar1->addAction(actPrint_);
 
+    connect(g_ThisVF, &QInputVF::saveSignal, this, &QZoomWnd::onSaveSignal);
+    connect(g_ThisVF, &QInputVF::loadSignal, this, &QZoomWnd::onLoadSignal);
+
 #ifdef TOOLTIPS
     actClose_->setToolTip(
         "Closes the plot window, all subwindows and zoom window");
@@ -73,7 +82,7 @@ QZoomWnd::QZoomWnd(QPlotWnd *main, int id, double x1, double y1, double x2,
     statusBar()->showMessage("Ready");
     addToolBar(Qt::TopToolBarArea, toolBar1);
 
-    sphere_ = new QWinSphere(this, statusBar(), true, x1, y1, x2, y2);
+    sphere_ = new QWinSphere(this, statusBar(), true, x1_, y1_, x2_, y2_);
     sphere_->show();
     setCentralWidget(sphere_);
     resize(NOMINALWIDTHPLOTWINDOW, NOMINALHEIGHTPLOTWINDOW);
@@ -89,6 +98,17 @@ QZoomWnd::~QZoomWnd()
 {
     delete sphere_;
     sphere_ = nullptr;
+}
+
+void QZoomWnd::onSaveSignal()
+{
+    QSettings settings(g_ThisVF->getbarefilename().append(".conf"));
+    settings.setValue("QZoomWnd/id",zoomid_);
+    settings.setValue("QZoomWnd/x1",x1_);
+    settings.setValue("QZoomWnd/y1",y1_);
+    settings.setValue("QZoomWnd/x2",x2_);
+    settings.setValue("QZoomWnd/y2",y2_);
+
 }
 
 void QZoomWnd::signalChanged(void)

--- a/src-gui/p4/win_zoom.cpp
+++ b/src-gui/p4/win_zoom.cpp
@@ -20,17 +20,17 @@
 #include "win_zoom.h"
 
 #include "custom.h"
+#include "file_vf.h"
 #include "main.h"
 #include "p4application.h"
 #include "plot_tools.h"
 #include "win_event.h"
 #include "win_print.h"
-#include "file_vf.h"
 
 #include <QDesktopWidget>
 #include <QPrintDialog>
-#include <QToolBar>
 #include <QSettings>
+#include <QToolBar>
 
 QZoomWnd::QZoomWnd(QPlotWnd *main, int id, double x1, double y1, double x2,
                    double y2)
@@ -45,7 +45,8 @@ QZoomWnd::QZoomWnd(QPlotWnd *main, int id, double x1, double y1, double x2,
     y2_ = y2;
 
     //    QPalette palette;
-    //    palette.setColor(backgroundRole(), QXFIGCOLOR(CBACKGROUND) );
+    //    palette.setColor(backgroundRole(), QXFIGCOLOR(bgColours::CBACKGROUND)
+    //    );
     //    setPalette(palette);
 
     if (g_p4smallicon != nullptr)
@@ -101,16 +102,17 @@ QZoomWnd::~QZoomWnd()
 
 void QZoomWnd::onSaveSignal()
 {
-    QSettings settings(g_ThisVF->getbarefilename().append(".conf"),QSettings::NativeFormat);
+    QSettings settings(g_ThisVF->getbarefilename().append(".conf"),
+                       QSettings::NativeFormat);
     settings.beginGroup(QString("QZoomWnd").append(zoomid_));
-    settings.setValue("id",zoomid_);
-    settings.setValue("x1",x1_);
-    settings.setValue("y1",y1_);
-    settings.setValue("x2",x2_);
-    settings.setValue("y2",y2_);
-    
-    settings.setValue("size",size());
-    settings.setValue("pos",pos());
+    settings.setValue("id", zoomid_);
+    settings.setValue("x1", x1_);
+    settings.setValue("y1", y1_);
+    settings.setValue("x2", x2_);
+    settings.setValue("y2", y2_);
+
+    settings.setValue("size", size());
+    settings.setValue("pos", pos());
     settings.endGroup();
 }
 

--- a/src-gui/p4/win_zoom.cpp
+++ b/src-gui/p4/win_zoom.cpp
@@ -31,7 +31,6 @@
 #include <QPrintDialog>
 #include <QToolBar>
 #include <QSettings>
-#include <iostream>
 
 QZoomWnd::QZoomWnd(QPlotWnd *main, int id, double x1, double y1, double x2,
                    double y2)
@@ -101,7 +100,7 @@ QZoomWnd::~QZoomWnd()
 }
 
 void QZoomWnd::onSaveSignal()
-{ //TODO: aixo no es guarda
+{
     QSettings settings(g_ThisVF->getbarefilename().append(".conf"),QSettings::NativeFormat);
     settings.beginGroup(QString("QZoomWnd").append(zoomid_));
     settings.setValue("id",zoomid_);
@@ -113,9 +112,6 @@ void QZoomWnd::onSaveSignal()
     settings.setValue("size",size());
     settings.setValue("pos",pos());
     settings.endGroup();
-
-    std::cerr << "zoom window reacts to save signal" << std::endl;
-
 }
 
 void QZoomWnd::signalChanged(void)

--- a/src-gui/p4/win_zoom.cpp
+++ b/src-gui/p4/win_zoom.cpp
@@ -31,6 +31,7 @@
 #include <QPrintDialog>
 #include <QToolBar>
 #include <QSettings>
+#include <iostream>
 
 QZoomWnd::QZoomWnd(QPlotWnd *main, int id, double x1, double y1, double x2,
                    double y2)
@@ -70,7 +71,6 @@ QZoomWnd::QZoomWnd(QPlotWnd *main, int id, double x1, double y1, double x2,
     toolBar1->addAction(actPrint_);
 
     connect(g_ThisVF, &QInputVF::saveSignal, this, &QZoomWnd::onSaveSignal);
-    connect(g_ThisVF, &QInputVF::loadSignal, this, &QZoomWnd::onLoadSignal);
 
 #ifdef TOOLTIPS
     actClose_->setToolTip(
@@ -101,13 +101,20 @@ QZoomWnd::~QZoomWnd()
 }
 
 void QZoomWnd::onSaveSignal()
-{
-    QSettings settings(g_ThisVF->getbarefilename().append(".conf"));
-    settings.setValue("QZoomWnd/id",zoomid_);
-    settings.setValue("QZoomWnd/x1",x1_);
-    settings.setValue("QZoomWnd/y1",y1_);
-    settings.setValue("QZoomWnd/x2",x2_);
-    settings.setValue("QZoomWnd/y2",y2_);
+{ //TODO: aixo no es guarda
+    QSettings settings(g_ThisVF->getbarefilename().append(".conf"),QSettings::NativeFormat);
+    settings.beginGroup(QString("QZoomWnd").append(zoomid_));
+    settings.setValue("id",zoomid_);
+    settings.setValue("x1",x1_);
+    settings.setValue("y1",y1_);
+    settings.setValue("x2",x2_);
+    settings.setValue("y2",y2_);
+    
+    settings.setValue("size",size());
+    settings.setValue("pos",pos());
+    settings.endGroup();
+
+    std::cerr << "zoom window reacts to save signal" << std::endl;
 
 }
 

--- a/src-gui/p4/win_zoom.h
+++ b/src-gui/p4/win_zoom.h
@@ -45,23 +45,28 @@ class QZoomWnd : public QMainWindow
     QAction *actClose_;
     QAction *actRefresh_;
     QAction *actPrint_;
+    double x1_,x2_,y1_,y2_;
 
     QWinSphere *sphere_; // main sphere
 
   public slots:
-    void signalEvaluating(void);
-    void signalEvaluated(void);
-    void signalChanged(void);
+  //TODO: maybe change these 3 to actual signals?
+    void signalEvaluating();
+    void signalEvaluated();
+    void signalChanged();
 
-    void onBtnClose(void);
-    void onBtnRefresh(void);
-    void onBtnPrint(void);
-    bool close(void);
+    void onBtnClose();
+    void onBtnRefresh();
+    void onBtnPrint();
+    bool close();
 
-    void configure(void);
+    void configure();
     void customEvent(QEvent *e);
     void hideEvent(QHideEvent *h);
-    void adjustHeight(void);
+    void adjustHeight();
+
+    void onSaveSignal();
+    void onLoadSignal();
 };
 
 #endif /* WIN_ZOOM_H */

--- a/src-gui/p4/win_zoom.h
+++ b/src-gui/p4/win_zoom.h
@@ -66,7 +66,6 @@ class QZoomWnd : public QMainWindow
     void adjustHeight();
 
     void onSaveSignal();
-    void onLoadSignal();
 };
 
 #endif /* WIN_ZOOM_H */

--- a/src-gui/version.h
+++ b/src-gui/version.h
@@ -29,5 +29,5 @@
 
 *************************************************************************/
 
-#define VERSION "6.0.0"
-#define VERSIONDATE "October, 2017"
+#define VERSION "7.0.0"
+#define VERSIONDATE "November, 2017"


### PR DESCRIPTION
# Changelog:

## New features
- The _Save_ button now saves more! The parameters were already stored, but now also the current state and geometry of the main and plot windows are saved, and also all the zoom windows, output window (the output is stored and there is no need of re-evaluating), and view finite and infinite results panels. All is stored in a "name.conf" file besides the other files generated by P4, and loaded back when the _Load_ button is pressed.
- Now you can select the colour of the plots background between black (default) and white (which looks like the printed images). This setting is located in  _About P4... > Main settings_.
- Now you can also select the colour scheme of the printed images (black or white, same as with the plot window). This setting is located in the _Print_ window that is open from the plot panel.

## Removed features
-  _Parameters_ and _Vector field_ buttons, that were used to hide parts of the UI and were not really necessary.
- The "small arrow button" that was used to hide all the UI except the top buttons and name field was also removed.

## Improvements
- The plot window now adapts to the size of the toolbars, so no buttons are hidden depending on the theme of the operative system.

## New dependencies
- _Boost library_ is now needed by P4, because the implementation of the linked list of zoom windows (so we can keep track of the currently open zoom windows) was changed to a more robust one (and one that allowed saving and restoring the information from a file). The Unix compile-install script now checks for this dependency and suggest installation instructions if it is not found.

## Planned future features
- **Soon**: The separatrices, orbits, curves and isoclines that were plotted will be saved along the configuration, so they are restored upon pressing load without performing extra calculations. How to implement this feature is still being investigated.
- **Next major release**: we will add the possibility of "dynamically visualizing" the evolution of the phase portrait of vector fields that depend on a parameter, gradually changing the value of this parameter within a specified range. This will produce a grid of plots where users will be able to see this evolution.
